### PR TITLE
Fixing package name, removing req to have KBID

### DIFF
--- a/QnAMaker/bin/qnamaker
+++ b/QnAMaker/bin/qnamaker
@@ -177,9 +177,7 @@ function validateConfig(config) {
     // ServiceBase.js
     const {subscriptionKey, knowledgeBaseID, endpointBasePath} = config;
     const messageTail = `is missing from the configuration.\n\nDid you run ${chalk.cyan.bold('qnamaker --init')} yet?`;
-
     assert(typeof subscriptionKey === 'string', `The subscriptionKey ${messageTail}`);
-    assert(typeof knowledgeBaseID === 'string', `The knowledgeBaseID ${messageTail}`);
     assert(typeof endpointBasePath === 'string', `The endpointBasePath ${messageTail}`);
 }
 

--- a/QnAMaker/package.json
+++ b/QnAMaker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "luis-apis",
+  "name": "qnamaker",
   "version": "1.0.7",
   "description": "Tooling for connectivity with the QnA Maker APIs",
   "main": "lib/api/index.js",


### PR DESCRIPTION
Removing the requirement to have KB ID always specified (you don't need this when you are trying to create a new KB). 

Also fixing the package.json for this package to be "QnAMaker"