### PR TITLE
luis subskey is optional aka.ms links for help with keys encrypt qnakey

### DIFF
--- a/MSBot/bin/msbot-connect-luis.js
+++ b/MSBot/bin/msbot-connect-luis.js
@@ -57,9 +57,10 @@ async function processConnectLuisArgs(config) {
     if (!args.version || parseInt(args.version))
         throw new Error("bad or missing --version");
     if (!args.authoringKey || !utils_1.uuidValidate(args.authoringKey))
-        throw new Error("bad or missing --authoringKey");
-    if (!args.subscriptionKey || !utils_1.uuidValidate(args.subscriptionKey))
-        throw new Error("bad or missing --subscriptionKey");
+        throw new Error("bad or missing --authoringKey. See http://aka.ms/luiskeys for help");
+    /*if (!args.subscriptionKey || !utils_1.uuidValidate(args.subscriptionKey))
+        throw new Error("bad or missing --subscriptionKey. See http://aka.ms/luiskeys for help");
+    */
     // add the service
     config.connectService({
         type: BotConfig_1.ServiceType.Luis,

--- a/MSBot/bin/msbot-connect-qna.js
+++ b/MSBot/bin/msbot-connect-qna.js
@@ -54,14 +54,14 @@ async function processConnectQnaArgs(config) {
     if (!args.hasOwnProperty('name'))
         throw new Error("missing --name");
     if (!args.subscriptionKey || !utils_1.uuidValidate(args.subscriptionKey))
-        throw new Error("bad or missing --subscriptionKey");
+        throw new Error("bad or missing --subscriptionKey. See http://aka.ms/qnakeys for help.");
     // add the service
     config.connectService({
         type: BotConfig_1.ServiceType.QnA,
         name: args.name,
         id: args.kbid,
         kbid: args.kbid,
-        subscriptionKey: args.subscriptionKey
+        subscriptionKey: config.encryptValue(args.subscriptionKey)
     });
     await config.Save();
     return config;


### PR DESCRIPTION
- Marked LUIS subscription key as optional - most devs won't need this until they run out of metered limits with their authoring key (which also doubles up as endpoint key)
- Added aka.ms links for luis and QnA so users can find their subscription key (aka.ms/luiskeys and aka.ms/qnakeys point to respective help pages)
- Fixed a bug where QnA subscription key wasn't encrypted.