### PR TITLE
Fix for Update Knowledgebase API call

### DIFF
--- a/QnAMaker/lib/api/knowledgebase.js
+++ b/QnAMaker/lib/api/knowledgebase.js
@@ -32,5 +32,11 @@ class Knowledgebase extends ServiceBase {
     getKnowledgebaseDetails(params) {
         return this.createRequest('', params, 'get');
     }
+    /**
+    * 
+    */
+    updateKnowledgebase(params , updateKb/* UpdateKbOperationDTO */) {
+        return this.createRequest('', params, 'PATCH', updateKb);
+    }
 }
 module.exports = Knowledgebase;

--- a/QnAMaker/lib/api/qnamaker.json
+++ b/QnAMaker/lib/api/qnamaker.json
@@ -88,7 +88,7 @@
   },
   "knowledgebase": {
     "className": "Knowledgebase",
-    "url": "/knowledgebase/{kbId}",
+    "url": "/knowledgebases/{kbId}",
     "operations": {
       "replaceKnowledgebase": {
         "name": "replaceKnowledgebase",
@@ -188,6 +188,30 @@
           }
         ],
         "description": "Get metadata about a knowledgebase"
+      },
+      "updateKnowledgebase": {
+        "name": "updateKnowledgebase",
+        "method": "PATCH",
+        "methodAlias": "update",
+        "target": [
+          "kb",
+          "knowledgebase"
+        ],
+        "command": "qnamaker update kb --in updateKb.json --kbId <string>",
+        "pathFragment": "",
+        "params": [
+          {
+            "type": "string",
+            "name": "kbId",
+            "in": "path",
+            "required": true,
+            "x-nullable": false,
+            "description": "Knowledgebase id"
+          }
+        ],
+        "description": "Add or delete QnA Pairs and / or URLs to an existing knowledge base",
+        "entityName": "updateKb",
+        "entityType": "UpdateKbOperationDTO"
       }
     }
   },


### PR DESCRIPTION
Current behavior for the QnAMaker REST api v4 is that the Update Knowledgebase operation's endpoint is "/knowledgebases/{kbId}", not "knowledgebases/{kbId}/UpdateAsync". Leaving both in for now, in case it changes or something.