### PR TITLE
fix to use NPM package

### DIFF
--- a/LUIS/lib/api/serviceBase.js
+++ b/LUIS/lib/api/serviceBase.js
@@ -4,7 +4,7 @@
  */
 const {insertParametersFromObject} = require('../utils/insertParametersFromObject');
 const deriveParamsFromPath = require('../utils/deriveParamsFromPath');
-
+const fetch = require('node-fetch');
 /**
  * Base class for all services
  */
@@ -33,6 +33,7 @@ class ServiceBase {
      * @returns {Promise<Response>} The promise representing the request
      */
     createRequest(pathFragment, params, method, dataModel = null) {
+        if (params) Object.assign(ServiceBase.config,params);
         const {commonHeaders: headers, endpoint} = this;
         const {endpointBasePath, appId, versionId} = ServiceBase.config;
         const tokenizedUrl = endpointBasePath + endpoint + pathFragment;


### PR DESCRIPTION
Fixes #
#124 

## Proposed Changes

There are two issues:

1) sample code used from NPM package page throws error of Fetch not found. Sticking it in the global, as it is currently done is not working for the NPM package usage. This fix adds the dependency to the top of serviceBase.js. 

2) Calling via npm package instead of cli, there is no way to pass in LUIS config values because the API begins at /api/lib and the params passed into a method are not overriding the serviceBase.config values. This fix allows the method call with params to fix that. I could see an argument for beginning the package at /api instead but the config settings at the top of serviceBase is not clear what the code is attempting to do. 

correct example call: 

```
var LUIS = require('luis-apis').Apps;
var config = require('dotenv').config;
config();
var getApps = async() =>{
    try{

        var ApiApps = new LUIS.Apps();
        
        var response = await ApiApps.Get({
            appId: process.env.LUIS_APP_ID, 
            versionId:process.env.LUIS_VERSION_ID, 
            authoringKey: process.env.LUIS_AUTHORING_KEY,
            endpointBasePath: process.env.LUIS_ENDPOINT_BASE_PATH
        });

        var body = await response.json();

        console.log(body);

    }catch(err){
        console.log(err);
    }
}

getApps();
```

## Testing
You don't have any npm-package based tests so I didn't want to assume anything here. I'm happy to write mocha tests though. 

## Docs
The docs for the NPM package are light. I would love to be able to use this package when I write the 
samples for the LUIS docs. If you would like some help with these docs, let me know. 