### PR TITLE
Tiens

### DIFF
--- a/Dispatch/package.json
+++ b/Dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botdispatch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tool to create LUIS model to dispatch intent among different bot components (multiple LUIS, QnA, etc)",
   "scripts": {
     "start": "dotnet bin/netcoreapp2.0/Dispatch.dll",

--- a/Dispatch/readme.md
+++ b/Dispatch/readme.md
@@ -76,7 +76,7 @@ Arguments
 | -t, --type   | luis, qna, file|
 | -i, --id     | (required only if type is luis/qna) LUIS app id or QnA kb id from application settings page|
 | -n, --name   | LUIS app name or QnA name (from application settings page) or module/file name for file type |
-| -k, --key    | (required only if type is luis/qna) LUIS authoring key (from https://www.luis.ai/user/settings) or QnA maker key (from https://qnamaker.ai/UserSettings) |
+| -k, --key    | (required only if type is luis/qna) LUIS authoring key (from https://www.luis.ai/user/settings) or QnA maker key (from QnA Maker Cognitive Service resource page on https://ms.portal.azure.com) |
 | -v, --version| (Required only if type is luis) LUIS app version |
 | -f, --filePath| (Required only if type is file) Path to tsv file containing tab delimited intent and utterance fields or .txt file with an utterance on each line |
 | --dispatch    | (optional) Path to .dispatch file |


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->
Outdated QnA Maker key info, it needs to point to key in Azure due to the QnA Maker upgrade for GA.  Info from dispatch usage is correct, only readme on GitHub/Microsoft/botbuilder-tool needs to be updated.

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

  - 
  -
  -


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->