### PR TITLE
using str.indexOf to avoid issues when entity text includes regexp control characters

### DIFF
--- a/Ludown/lib/parseFileContents.js
+++ b/Ludown/lib/parseFileContents.js
@@ -199,7 +199,7 @@ module.exports.parseFile = function(fileContent, log)
                                     // add this to entities collection unless it already exists
                                     addItemIfNotPresent(LUISJsonStruct, LUISObjNameEnum.ENTITIES, entity);
                                     // clean up uttearnce to only include labelledentityValue and add to utterances collection
-                                    var startPos = updatedUtterance.search(srcEntityStructure);
+                                    var startPos = updatedUtterance.indexOf(srcEntityStructure);
                                     var endPos = startPos + labelledValue.length - 1;
                                     updatedUtterance = updatedUtterance.replace("{" + entity + "=" + labelledValue + "}", labelledValue);
                                     entitiesInUtterance.push({


### PR DESCRIPTION
str.search used a regexp and any special characters such as $, [, (, ], ), ^ will create problems. Since we are doing a replace above and then looking for indexOf for the replace text, this should be good. All tests pass.

Fixes #198 

## Proposed Changes
Using str.indexOf instead of str.search as str.search assumes regexp matching.

## Test Input
```
> # Intent definitions
## None

## TestIntent
- test funky {EntityOne=$symbol} in entity
- test funky {EntityOne=[symbol]} in entity
- test funky {EntityOne=this$ is a [weird] entity} but oh well
- another {EntityOne=te$st}
- another {EntityOne=te&st}

> # Entity definitions
$EntityOne:simple
$EntityTwo:simple
> # PREBUILT Entity definitions
> # Phrase list definitions
> # List entities
```

## Output With Current Release
```
{
  "intents": [
    {
      "name": "None"
    },
    {
      "name": "TestIntent"
    }
  ],
  "entities": [
    {
      "name": "EntityOne",
      "roles": []
    },
    {
      "name": "EntityTwo",
      "roles": []
    }
  ],
  "composites": [],
  "closedLists": [],
  "regex_entities": [],
  "model_features": [],
  "regex_features": [],
  "utterances": [
    {
      "text": "test funky $symbol in entity",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": -1,
          "endPos": 5
        }
      ]
    },
    {
      "text": "test funky [symbol] in entity",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": -1,
          "endPos": 6
        }
      ]
    },
    {
      "text": "test funky this$ is a [weird] entity but oh well",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": -1,
          "endPos": 23
        }
      ]
    },
    {
      "text": "another te$st",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": -1,
          "endPos": 3
        }
      ]
    },
    {
      "text": "another te&st",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": 8,
          "endPos": 12
        }
      ]
    }
  ],
  "patterns": [],
  "patternAnyEntities": [],
  "prebuiltEntities": [],
  "luis_schema_version": "3.0.0",
  "versionId": "0.1",
  "name": "repro3",
  "desc": "",
  "culture": "en-us"
}
```
## Output with Fix
```
{
  "intents": [
    {
      "name": "None"
    },
    {
      "name": "TestIntent"
    }
  ],
  "entities": [
    {
      "name": "EntityOne",
      "roles": []
    },
    {
      "name": "EntityTwo",
      "roles": []
    }
  ],
  "composites": [],
  "closedLists": [],
  "regex_entities": [],
  "model_features": [],
  "regex_features": [],
  "utterances": [
    {
      "text": "test funky $symbol in entity",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": 11,
          "endPos": 17
        }
      ]
    },
    {
      "text": "test funky [symbol] in entity",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": 11,
          "endPos": 18
        }
      ]
    },
    {
      "text": "test funky this$ is a [weird] entity but oh well",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": 11,
          "endPos": 35
        }
      ]
    },
    {
      "text": "another te$st",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": 8,
          "endPos": 12
        }
      ]
    },
    {
      "text": "another te&st",
      "intent": "TestIntent",
      "entities": [
        {
          "entity": "EntityOne",
          "startPos": 8,
          "endPos": 12
        }
      ]
    }
  ],
  "patterns": [],
  "patternAnyEntities": [],
  "prebuiltEntities": [],
  "luis_schema_version": "3.0.0",
  "versionId": "0.1",
  "name": "repro3",
  "desc": "",
  "culture": "en-us"
}
```