### PR TITLE
Fixes to get QnAMaker replace command working

### DIFF
--- a/QnAMaker/examples/ReplaceKbDTO.json
+++ b/QnAMaker/examples/ReplaceKbDTO.json
@@ -1,0 +1,18 @@
+{
+  "qnAList": [
+    {
+      "id": 0,
+      "answer": "string",
+      "source": "string",
+      "questions": [
+        "string"
+      ],
+      "metadata": [
+        {
+          "name": "string",
+          "value": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/QnAMaker/lib/api/dataModels/replaceKbDto.js
+++ b/QnAMaker/lib/api/dataModels/replaceKbDto.js
@@ -3,7 +3,7 @@
   * Licensed under the MIT License.
   */
 
-
+const QnADTO = require('./qnAdto');
 class ReplaceKbDTO {
     
     /**
@@ -23,7 +23,7 @@ ReplaceKbDTO.fromJSON = function(src) {
         return src.map(ReplaceKbDTO.fromJSON);
     }
     
-    src.qnAList = QnADTO.fromJSON(src.qnAList) || undefined;
+    src.qnAList = QnADTO.fromJSON(src.qnAList) || QnADTO.fromJSON(src.qnaList) || undefined;
 
     const {qnAList /* QnADTO[] */} = src;
     return new ReplaceKbDTO({qnAList /* QnADTO[] */});

--- a/QnAMaker/lib/help.js
+++ b/QnAMaker/lib/help.js
@@ -149,7 +149,9 @@ function getGeneralHelpContents(output) {
             [chalk.cyan.bold("query"), "query model for prediction"],
             [chalk.cyan.bold("refresh"), "refresh resources"],
             [chalk.cyan.bold("set"), "change the .qnamakerrc settings"],
-            [chalk.cyan.bold("update"), "update resources"]
+            [chalk.cyan.bold("update"), "update resources"],
+            [chalk.cyan.bold("replace"), "replace a resource"]
+            
         ]
     };
 

--- a/QnAMaker/package-lock.json
+++ b/QnAMaker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qnamaker",
-  "version": "1.0.29",
+  "version": "1.0.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/QnAMaker/package.json
+++ b/QnAMaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qnamaker",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Tooling for connectivity with the QnA Maker APIs",
   "main": "lib/api/index.js",
   "bin": {


### PR DESCRIPTION
Fixes #227 

1. Fixed the issue
2. Added an example qna replace document so this shows up with qnamaker replace kb -h
3. Updated the root help table so replace command shows up under qnamaker -h
