### PR TITLE
[Chatdown] Added default value to arg in readContents()

### DIFF
--- a/Chatdown/lib/index.js
+++ b/Chatdown/lib/index.js
@@ -35,7 +35,7 @@ let workingDirectory;
  * @param args The k/v pair representing the configuration options
  * @returns {Promise<Array>} Resolves with an array of Activity objects.
  */
-module.exports = async function readContents(fileContents, args) {
+module.exports = async function readContents(fileContents, args = {}) {
     // Resolve file paths based on the input file with a fallback to the cwd
     workingDirectory = args.in ? path.dirname(path.resolve(args.in)) : __dirname;
     const activities = [];


### PR DESCRIPTION
While trying to consume Chatdown as a library in the emulator, I ran into an issue where calling

`chatdown(chatFileContents)` was throwing an error because I wasn't passing in an empty `args` object

## Proposed Changes
  - added a default value to `args` parameter in `readContents()` function
  - this will prevent the function from throwing an undefined reference error when it checks `args.in` when an args object is omitted from the call