### PR TITLE
sgellock chatdown lib tests

### DIFF
--- a/Chatdown/lib/index.js
+++ b/Chatdown/lib/index.js
@@ -480,7 +480,7 @@ async function addAttachment(activity, arg) {
         // if it is not a card
         if (!isCard(contentType) && charset !== 'UTF-8') {
             // send as base64
-            contentUrl = `data:${contentType};base64,${new Buffer(content).toString('base64')}`;
+            contentUrl = `data:${contentType};base64,${new Buffer.alloc(content.length).toString('base64')}`;
             content = undefined;
         } else {
             contentUrl = undefined;

--- a/Chatdown/package.json
+++ b/Chatdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Tool for parsing chat files and outputting replayable activities",
   "main": "lib/index.js",
   "directories": {
@@ -17,7 +17,7 @@
     "url": "git+https://github.com/Microsoft/botbuilder-tools.git"
   },
   "author": "Microsoft",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Microsoft/botbuilder-tools/issues"
   },

--- a/Chatdown/test/chatdown.lib.test.suite.js
+++ b/Chatdown/test/chatdown.lib.test.suite.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const chatdown = require('../lib');
 
-describe('The chatdown lib', () => {
+describe('The Chatdown lib', () => {
     describe('should correctly output data', () => {
         it('when the input chat contains an attachment', async () => {
 const conversation = `
@@ -42,7 +42,7 @@ bot=LulaBot
 user: Hello!
 bot: [Typing]
 [Delay=5000] How are you?,
-user: Good, hit me with a help fiassert(activities[3].Attachment.length);le!
+user: Good, hit me with a help file!
 bot: [Attachment=help.json] here you go!
 `;
 


### PR DESCRIPTION
Fixes 
- replaced nodejs deprecated Buffer allocation for base64 codepath
- minor text changes in the lib tests to fix typos or to make things consistent with cli tests

## Testing
ran a full test suite run:  'npm test'