### PR TITLE
add --static to have fixed start timestamp

### DIFF
--- a/Chatdown/lib/help.js
+++ b/Chatdown/lib/help.js
@@ -10,7 +10,7 @@ module.exports = function (output) {
     if (!output)
         output = process.stderr;
     output.write('\nChatdown cli tool used to parse chat dialogs (.chat file) into a mock transcript file\n\n© 2018 Microsoft Corporation\n\n');
-    output.write(chalk.cyan.bold(`chatdown [chat] [--help] [--version]\n\n`));
+    output.write(chalk.cyan.bold(`chatdown [chat] [--help] [--version] [--static]\n\n`));
     let left = 20;
     let right = windowSize.width - left - 3; // 3 is for 3 vertical bar characters
     const table = new Table({
@@ -29,5 +29,6 @@ module.exports = function (output) {
     table.push([chalk.cyan.bold('[chat]'), '[chat] is the location of the chat file to parse. If omitted, piping is assumed and stdin will be used for input.']);
     table.push([chalk.cyan.bold('-v, --version'), 'show version']);
     table.push([chalk.cyan.bold('--help'), 'Prints this help info to the console.']);
+    table.push([chalk.cyan.bold('--static'), 'use static timestamps when generating timestamps on activities.']);
     output.write(table.toString()+'\n');
 };

--- a/Chatdown/lib/index.js
+++ b/Chatdown/lib/index.js
@@ -35,6 +35,9 @@ let workingDirectory;
  * @returns {Promise<Array>} Resolves with an array of Activity objects.
  */
 module.exports = async function readContents(fileContents, args = {}) {
+    if (args.static || args.s) {
+        now = Number(new Date(2016, 9, 15, 12, 0, 0, 0));
+    }
     // Resolve file paths based on the input file with a fallback to the cwd
     workingDirectory = args.in ? path.dirname(path.resolve(args.in)) : __dirname;
     const activities = [];
@@ -178,7 +181,7 @@ function createConversationUpdate(args, membersAdded, membersRemoved) {
     });
     conversationUpdateActivity.membersAdded = membersAdded || [];
     conversationUpdateActivity.membersRemoved = membersRemoved || [];
-    conversationUpdateActivity.timestamp = getIncrementedDate();
+    conversationUpdateActivity.timestamp = getIncrementedDate(100);
     return conversationUpdateActivity;
 }
 
@@ -531,7 +534,7 @@ function createActivity({ type = ActivityTypes.Message, recipient, from, convers
 }
 
 function getIncrementedDate(byThisAmount = messageTimeGap) {
-    return new Date(now += +byThisAmount).toISOString();
+    return new Date(now += byThisAmount).toISOString();
 }
 
 /**

--- a/Chatdown/lib/index.js
+++ b/Chatdown/lib/index.js
@@ -36,7 +36,7 @@ let workingDirectory;
  */
 module.exports = async function readContents(fileContents, args = {}) {
     if (args.static || args.s) {
-        now = Number(new Date(2016, 9, 15, 12, 0, 0, 0));
+        now = Number(new Date(2015, 9, 15, 12, 0, 0, 0));
     }
     // Resolve file paths based on the input file with a fallback to the cwd
     workingDirectory = args.in ? path.dirname(path.resolve(args.in)) : __dirname;

--- a/Chatdown/package.json
+++ b/Chatdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Tool for parsing chat files and outputting replayable activities",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
When generating a transcript for unit tests it is useful to have fixed timestamps.  to support this I added a --static switch which sets the time of the first activity to the time that the Bot Framework project was started.
