### PR TITLE
Aggregate coverage results for coveralls integration

### DIFF
--- a/Chatdown/package.json
+++ b/Chatdown/package.json
@@ -7,8 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "cd test/ && mocha --opts mocha.opts",
-    "test:travis": "cd test/ && nyc mocha --opts mocha.opts && nyc report --reporter=text-lcov | coveralls"
+    "test": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -41,8 +40,6 @@
     "chatdown": "./bin/chatdown"
   },
   "devDependencies": {
-    "coveralls": "^3.0.2",
-    "mocha": "^5.2.0",
-    "nyc": "^12.0.2"
+    "mocha": "^5.2.0"
   }
 }

--- a/Chatdown/test/chatdown.lib.test.suite.js
+++ b/Chatdown/test/chatdown.lib.test.suite.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const chatdown = require('../lib');
+const path = require('path');
+const botFrameworkPngPath = path.join(__dirname, 'bot-framework.png')
+const helpJsonPath = path.join(__dirname, 'help.json')
 
 describe('The chatdown lib', () => {
     describe('should correctly output data', () => {
@@ -10,7 +13,7 @@ bot=LulaBot
 user: Hello!
 bot: Hello, can I help you?
 user: I need an image
-bot: here you go! [Attachment=bot-framework.png]
+bot: here you go! [Attachment=${botFrameworkPngPath}]
 `;
             const activities = await chatdown(conversation, {});
             assert(activities.length === 5);
@@ -43,7 +46,7 @@ user: Hello!
 bot: [Typing]
 [Delay=5000] How are you?,
 user: Good, hit me with a help fiassert(activities[3].Attachment.length);le!
-bot: [Attachment=help.json] here you go!
+bot: [Attachment=${helpJsonPath}] here you go!
 `;
 
             const activities = await chatdown(conversation, {});
@@ -58,7 +61,7 @@ user: Hello!
 bot: [Typing]
 [Delay=5000] How are you?,
 user: Good, hit me with a help file!
-bot: [Attachment=bot-framework.png] here you go!
+bot: [Attachment=${botFrameworkPngPath}] here you go!
 `;
 
             const activities = await chatdown(conversation, {});
@@ -73,7 +76,7 @@ user: Hello!
 bot: [Typing]
 [Delay=5000] How are you?,
 user: Good, hit me with a help file!
-bot: [Attachment=help.json] here you go!
+bot: [Attachment=${helpJsonPath}] here you go!
 `;
 
             const activities = await chatdown(conversation, {});

--- a/LUIS/package.json
+++ b/LUIS/package.json
@@ -13,8 +13,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "cd test/ && mocha --opts mocha.opts",
-    "test:travis": "cd test/ && nyc mocha --opts mocha.opts && nyc report --reporter=text-lcov | coveralls"
+    "test": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {
     "node": ">=8.0"
@@ -51,9 +50,6 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^5.0.4",
-    "mocha-lcov-reporter": "^1.3.0",
-    "coveralls": "^3.0.2",
-    "nyc": "^12.0.2"
+    "mocha": "^5.0.4"
   }
 }

--- a/QnAMaker/package.json
+++ b/QnAMaker/package.json
@@ -13,8 +13,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "cd test/ && mocha --opts mocha.opts",
-    "test:travis": "cd test/ && nyc mocha --opts mocha.opts && nyc report --reporter=text-lcov | coveralls"
+    "test": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {
     "node": ">=8.0"
@@ -55,9 +54,6 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "mocha": "^5.0.4",
-    "mocha-lcov-reporter": "^1.3.0",
-    "coveralls": "^3.0.2",
-    "nyc": "^12.0.2"
+    "mocha": "^5.0.4"
   }
 }

--- a/build.ci.sh
+++ b/build.ci.sh
@@ -2,8 +2,14 @@ function install() {
     echo Install $1
     pushd $1
     npm install
-    if [ $2 ]; then npm run test:travis; fi
+    if [ $2 ]; then npm run test; fi
     popd
+}
+
+function coveralls() {
+    echo Run Coveralls Aggregated tests
+    npm install
+    npm run test:travis
 }
 
 function create_npmrc() {
@@ -49,6 +55,8 @@ else
         install LUISGen
         install MSBot
         install QnAMaker with_test
+
+        coveralls
     )
 fi
 errorcode=$?

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "botbuilder-tools",
+    "scripts": {
+        "test:travis": "nyc mocha \"@(Chatdown|LUIS|QnAMaker)*/test/*.test.suite.js\" --timeout 10000 && nyc report --reporter=text-lcov | coveralls"
+    },
+    "devDependencies": {
+        "coveralls": "^3.0.2",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2"
+    }
+}


### PR DESCRIPTION
## Proposed Changes
1. Create a centralized package.json file to instrument unit tests and gather code coverage metrics for coveralls service.
2. Remove instrumentation from each individual tools package
3. Adapt Chatdown unit tests to dynamically resolve relative paths to resource files used in tests.


## Testing
Once merged this PR code coverage results will appear in https://coveralls.io/github/Microsoft/botbuilder-tools