### PR TITLE
Ignore MSBot from ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/*
 **/node_modules/*
+MSBot/*


### PR DESCRIPTION
## Proposed Changes
- Ignore MSBot/* files from ESLint since it is entirely based in TS files