### PR TITLE
Fix for #324

### DIFF
--- a/Ludown/README.MD
+++ b/Ludown/README.MD
@@ -103,5 +103,6 @@ This CLI writes to stderr on error and stdout otherwise. CLI also returns the fo
 |SYNONYMS_NOT_A_LIST        | 18            |
 |PHRASELIST_NOT_A_LIST      | 19            |
 |TRANSLATE_SERVICE_FAIL     | 20            |
+|INVALID_URI                | 21            |
 |UNKNOWN_ERROR              | 99            |
 

--- a/Ludown/docs/lu-file-format.md
+++ b/Ludown/docs/lu-file-format.md
@@ -255,6 +255,12 @@ $botframework : qna-alterations=
 - Microsoft bot framework
 ```
 
+## QnA Maker pdf file ingestion
+QnA Maker also supports ingesting pdf files during KB creation. You can add files for QnA maker to ingest using the URL reference scheme. If the URI's content-type is not text/html, then the ludown parser will add it to files collection for QnA Maker to ingest. 
+
+```markdown
+[SurfaceManual.pdf](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf)
+```
 ## Adding comments
 You can add comments to your .lu document by prefixing the comment with >. Here's an example: 
 

--- a/Ludown/examples/qna3.lu
+++ b/Ludown/examples/qna3.lu
@@ -15,3 +15,6 @@ You can use our REST apis to manage your KB.
 
 > You can add URLs for QnA maker to ingest using the #URL reference scheme
 [QnA URL - faqs](https://docs.microsoft.com/en-in/azure/cognitive-services/qnamaker/faqs)
+
+> You can add files for QnA maker to ingest using the URL reference scheme. If the URI's content-type is not text/html, then the ludown parser will add it to files collection for QnA Maker to ingest. 
+[SurfaceManual.pdf](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf)

--- a/Ludown/lib/classes/qna.js
+++ b/Ludown/lib/classes/qna.js
@@ -9,9 +9,13 @@ class QnA {
     /**
      * @property {qnaListObj []} qnaList
      */
-    constructor(urls, qnaList) {
+    /**
+     * @property {string []} files
+     */
+    constructor(urls, qnaList, files) {
         this.urls = urls?urls:[];
         this.qnaList = qnaList?qnaList:[];
+        this.files = files?files:[];
     }
 }
 

--- a/Ludown/lib/classes/qnaFiles.js
+++ b/Ludown/lib/classes/qnaFiles.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+class qnaFile { 
+    /**
+     * @property {string} fileUri
+     */
+    /**
+     * @property {string} fileName
+     */
+    
+    constructor(fileUri, fileName) {
+        this.fileName = fileName?fileName:'';
+        this.fileUri = fileUri?fileUri:'';
+    }
+}
+
+module.exports = qnaFile;

--- a/Ludown/lib/enums/CLI-errors.js
+++ b/Ludown/lib/enums/CLI-errors.js
@@ -25,6 +25,7 @@ module.exports = {
         SYNONYMS_NOT_A_LIST:        18,
         PHRASELIST_NOT_A_LIST:      19,
         TRANSLATE_SERVICE_FAIL:     20,
+        INVALID_URI:                21,
         UNKNOWN_ERROR:              99   
     }
 };

--- a/Ludown/test/ludown.qnafiles.test.suite.js
+++ b/Ludown/test/ludown.qnafiles.test.suite.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+const chai = require('chai');
+const assert = chai.assert;
+const parseFile = require('../lib/parseFileContents').parseFile;
+const collateFiles = require('../lib/parseFileContents').collateQnAFiles;
+const retCode = require('../lib/enums/CLI-errors').errorCode;
+describe('With parse file function', function() {
+    it('Throws when input lu file has invalid URIs', function(done){
+        let fileContent = `[InvalidPDF](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN2.pdf)`;
+        parseFile(fileContent, false, null)
+            .then(res => done('Test fail! did not throw when expected'))
+            .catch(err => {
+                assert.equal(err.errCode, retCode.INVALID_URI);
+                done()
+            })
+    });
+
+    it('correctly parses files available for ingestion in parse toqna', function(done){
+        let fileContent = `[Valid PDF](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf)`;
+        parseFile(fileContent, false, null)
+            .then(res => {
+                assert.equal(res.qnaJsonStructure.files[0].fileUri, 'https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf');
+                done();
+            })
+            .catch(err => done(err))
+    });
+
+    it('correctly collates multiple file references in parse toqna', async function() {
+        let fileContent = `[Valid PDF](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf)`;
+        let Blob1 = await parseFile(fileContent, false, null);
+        let Blob2 = await parseFile(fileContent, false, null);
+        collateFiles([Blob1.qnaJsonStructure, Blob2.qnaJsonStructure])
+            .then(res => {
+                assert.equal(res.files[0].fileUri, 'https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf');
+            })
+            .catch(err => {throw(err)});
+    })
+
+});

--- a/Ludown/test/testcases/collate/qna3.lu
+++ b/Ludown/test/testcases/collate/qna3.lu
@@ -15,3 +15,6 @@ You can use our REST apis to manage your KB.
 
 > You can add URLs for QnA maker to ingest using the #URL reference scheme
 [QnA URL - faqs](https://docs.microsoft.com/en-in/azure/cognitive-services/qnamaker/faqs)
+
+> You can add files for QnA maker to ingest using the URL reference scheme. If the URI's content-type is not text/html, then the ludown parser will add it to files collection for QnA Maker to ingest. 
+[SurfaceManual.pdf](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf)

--- a/Ludown/test/verified/12qna.json
+++ b/Ludown/test/verified/12qna.json
@@ -32,5 +32,6 @@
       "metadata": []
     }
   ],
+  "files": [],
   "name": "12qna"
 }

--- a/Ludown/test/verified/all-qna.json
+++ b/Ludown/test/verified/all-qna.json
@@ -78,5 +78,6 @@
       ]
     }
   ],
+  "files": [],
   "name": "all-qna"
 }

--- a/Ludown/test/verified/collate-qna.json
+++ b/Ludown/test/verified/collate-qna.json
@@ -87,5 +87,11 @@
       ]
     }
   ],
+  "files": [
+    {
+      "fileName": "SurfaceManual.pdf",
+      "fileUri": "https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf"
+    }
+  ],
   "name": "collate-qna"
 }


### PR DESCRIPTION
Fixes #324 
## Proposed Changes
```markdown
## QnA Maker pdf file ingestion
QnA Maker also supports ingesting pdf files during KB creation. You can add files for QnA maker to ingest using the URL reference scheme. If the URI's content-type is not text/html, then the ludown parser will add it to files collection for QnA Maker to ingest. 

[SurfaceManual.pdf](https://download.microsoft.com/download/2/9/B/29B20383-302C-4517-A006-B0186F04BE28/surface-pro-4-user-guide-EN.pdf)
```

## Testing
Added new tests for file ingestion.