### PR TITLE
[Travis] Temporarily increase test timeout

### DIFF
--- a/Chatdown/test/mocha.opts
+++ b/Chatdown/test/mocha.opts
@@ -1,3 +1,3 @@
---timeout 10000
+--timeout 30000
 --recursive
 **/*.js

--- a/LUIS/test/mocha.opts
+++ b/LUIS/test/mocha.opts
@@ -1,3 +1,3 @@
+--timeout 30000
 --recursive
---timeout 10000
 **/*.js

--- a/QnAMaker/test/mocha.opts
+++ b/QnAMaker/test/mocha.opts
@@ -1,3 +1,3 @@
+--timeout 30000
 --recursive
---timeout 10000
 **/*.js


### PR DESCRIPTION
Related to #292 

## Proposed Changes
Randomly but often, CLI tools tests fail when for the --help switch (which should output the help message in the stdout). This is usually the first tets of the suite (for QnA, LUIS and Chatdown tools).

  - Temporarily increase the mocha.opts timeout setting from 10000 to 3000
  - Keep the original issue open since this is not a proper solution to the problem
  - Remove the timeout option in mocha.opts since unit tests should run flawlessly with defaults


## Testing
This happens mainly in Travis, locally is not that common. We should keep an eye on the Travis builds.