### PR TITLE
Fix travis build adding dotnet-2.0.0 as root devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,6 +2562,12 @@
                 "is-obj": "^1.0.0"
             }
         },
+        "dotnet-2.0.0": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/dotnet-2.0.0/-/dotnet-2.0.0-1.4.4.tgz",
+            "integrity": "sha512-KDbUncVUhwkJH2wjL9gbUWQ5NcZIe+PFEI0CGTMtX5TImFG6Nlt9CABVGBBG+oWf13zLARaBVenkD20moz1NPw==",
+            "dev": true
+        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "devDependencies": {
         "chai": "^4.1.2",
         "coveralls": "^3.0.2",
+        "dotnet-2.0.0": "^1.4.4",
         "eslint": "^5.2.0",
         "eslint-config-standard": "^11.0.0",
         "eslint-friendly-formatter": "^4.0.1",


### PR DESCRIPTION
Fixes build

## Proposed Changes
  - Add dotnet-2.0.0 as devDependency in root's package.json
  - This solves a race condition issue when installing the same dependency for LUISGen and Dispatch tools

## Testing
Travis build process should pass without errors