### PR TITLE
Fixed TSLint 'newline-before-return' warning in MSBot

### DIFF
--- a/packages/MSBot/src/BotConfig.ts
+++ b/packages/MSBot/src/BotConfig.ts
@@ -147,6 +147,7 @@ export class BotConfig extends BotConfigModel {
             if (service.id == nameOrId || service.name == nameOrId) {
                 svs.removeAt(i);
                 this.services = svs.toArray();
+
                 return service;
             }
         }
@@ -162,6 +163,7 @@ export class BotConfig extends BotConfigModel {
             if (service.type == type && service.id == id) {
                 svs.removeAt(i);
                 this.services = svs.toArray();
+
                 return;
             }
         }
@@ -177,6 +179,7 @@ export class BotConfig extends BotConfigModel {
 
             return this.internalEncrypt(value);
         }
+
         return value;
     }
 
@@ -190,6 +193,7 @@ export class BotConfig extends BotConfigModel {
 
             return this.internalDecrypt(encryptedValue);
         }
+
         return encryptedValue;
     }
 
@@ -231,6 +235,7 @@ export class BotConfig extends BotConfigModel {
             const val = <string>(<any>service)[prop];
             (<any>service)[prop] = this.encryptValue(val);
         }
+
         return service;
     }
 
@@ -242,6 +247,7 @@ export class BotConfig extends BotConfigModel {
             const val = <string>(<any>service)[prop];
             (<any>service)[prop] = this.decryptValue(val);
         }
+
         return service;
     }
 
@@ -249,6 +255,7 @@ export class BotConfig extends BotConfigModel {
         const cipher = crypto.createCipher('aes192', this.internal.secret);
         let encryptedValue = cipher.update(value, 'utf8', 'hex');
         encryptedValue += cipher.final('hex');
+
         return encryptedValue;
     }
 
@@ -256,6 +263,7 @@ export class BotConfig extends BotConfigModel {
         const decipher = crypto.createDecipher('aes192', this.internal.secret);
         let value = decipher.update(encryptedValue, 'hex', 'utf8');
         value += decipher.final('utf8');
+
         return value;
     }
 }

--- a/packages/MSBot/src/models/azureBotService.ts
+++ b/packages/MSBot/src/models/azureBotService.ts
@@ -19,6 +19,7 @@ export class AzureBotService extends ConnectedService implements IAzureBotServic
 
     public toJSON(): IAzureBotService {
         const { id, name, tenantId, subscriptionId, resourceGroup } = this;
+
         return { type: ServiceType.AzureBotService, id, name, tenantId, subscriptionId, resourceGroup };
     }
 }

--- a/packages/MSBot/src/models/botConfigModel.ts
+++ b/packages/MSBot/src/models/botConfigModel.ts
@@ -47,11 +47,13 @@ export class BotConfigModel implements Partial<IBotConfig> {
         services = services.slice().map(BotConfigModel.serviceFromJSON);
         const botConfig = new BotConfigModel();
         Object.assign(botConfig, { services, description, name, secretKey });
+
         return botConfig;
     }
 
     public toJSON(): Partial<IBotConfig> {
         const { name, description, services, secretKey } = this;
+
         return { name, description, services, secretKey };
     }
 }

--- a/packages/MSBot/src/models/dispatchService.ts
+++ b/packages/MSBot/src/models/dispatchService.ts
@@ -22,6 +22,7 @@ export class DispatchService extends ConnectedService implements IDispatchServic
 
     public toJSON(): IDispatchService {
         const { appId, authoringKey, name, serviceIds, subscriptionKey, version } = this;
+
         return {  type: ServiceType.Dispatch, id: appId, name, appId, authoringKey, serviceIds, subscriptionKey, version };
     }
 }

--- a/packages/MSBot/src/models/endpointService.ts
+++ b/packages/MSBot/src/models/endpointService.ts
@@ -21,6 +21,7 @@ export class EndpointService extends ConnectedService implements IEndpointServic
 
     public toJSON(): IEndpointService {
         const { appId = '', id = '', appPassword = '', endpoint = '', name = '' } = this;
+
         return { type: ServiceType.Endpoint, name, id: endpoint, appId, appPassword, endpoint };
     }
 }

--- a/packages/MSBot/src/models/fileService.ts
+++ b/packages/MSBot/src/models/fileService.ts
@@ -18,6 +18,7 @@ export class FileService extends ConnectedService implements IFileService {
 
     public toJSON(): IFileService {
         const { name = '', id = '', filePath = '' } = this;
+
         return { type: ServiceType.File, id: filePath, name, filePath };
     }
 }

--- a/packages/MSBot/src/models/luisService.ts
+++ b/packages/MSBot/src/models/luisService.ts
@@ -21,6 +21,7 @@ export class LuisService extends ConnectedService implements ILuisService {
 
     public toJSON(): ILuisService {
         const { appId, authoringKey, id, name, subscriptionKey, type, version } = this;
+
         return { type: ServiceType.Luis, id: appId, name, version, appId, authoringKey, subscriptionKey };
     }
 }

--- a/packages/MSBot/src/models/qnaMakerService.ts
+++ b/packages/MSBot/src/models/qnaMakerService.ts
@@ -25,6 +25,7 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
 
     public toJSON(): IQnAService {
         const { id, name, kbId, subscriptionKey, endpointKey, hostname } = this;
+
         return { type: ServiceType.QnA, id: kbId, name, kbId, subscriptionKey, endpointKey, hostname };
     }
 }

--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -129,12 +129,14 @@ async function processConnectAzureArgs(config: BotConfig): Promise<BotConfig> {
     }
     await config.save();
     process.stdout.write(JSON.stringify(services, null, 2));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -118,12 +118,14 @@ async function processConnectDispatch(config: BotConfig): Promise<BotConfig> {
     config.connectService(newService);
     await config.save();
     process.stdout.write(JSON.stringify(newService, null, 2));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -120,12 +120,14 @@ async function processConnectEndpointArgs(config: BotConfig): Promise<BotConfig>
 
     await config.save();
     process.stdout.write(JSON.stringify(newService, null, 2));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -68,12 +68,14 @@ async function processConnectFile(config: BotConfig): Promise<BotConfig> {
     config.connectService(newService);
     await config.save();
     process.stdout.write(JSON.stringify(newService, null, 2));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -101,12 +101,14 @@ async function processConnectLuisArgs(config: BotConfig): Promise<BotConfig> {
     config.connectService(newService);
     await config.save();
     process.stdout.write(JSON.stringify(newService, null, 2));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -101,12 +101,14 @@ async function processConnectQnaArgs(config: BotConfig): Promise<BotConfig> {
 
     await config.save();
     process.stdout.write(JSON.stringify(newService, null, 2));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect.ts
+++ b/packages/MSBot/src/msbot-connect.ts
@@ -31,6 +31,7 @@ if (args) {
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -64,6 +64,7 @@ async function processConnectAzureArgs(config: BotConfig): Promise<BotConfig> {
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -51,12 +51,14 @@ async function processListArgs(config: BotConfig): Promise<BotConfig> {
         description: config.description,
         services: config.services
     },                         null, 4));
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -57,12 +57,14 @@ async function processSecret(config: BotConfig): Promise<BotConfig> {
     }
 
     config.save(args.bot);
+
     return config;
 }
 
 function showErrorHelp() {
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -19,6 +19,7 @@ program.Command.prototype.unknownOption = function (flag: any) {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);
@@ -57,6 +58,7 @@ if (args) {
     console.error(chalk.default.redBright(`Unknown arguments: ${a.join(' ')}`));
     program.outputHelp((str) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);


### PR DESCRIPTION
Added a newline berofe `return` sentences in several files for correcting 'newline-before-return' warnings from TSLint in MSBot.