### PR TITLE
Fixed TSLint 'no-empty' warnings in MSBot

### DIFF
--- a/packages/MSBot/src/msbot-clone.ts
+++ b/packages/MSBot/src/msbot-clone.ts
@@ -14,9 +14,7 @@ program
     .name('msbot clone')
     .option('-bot, -b', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .description('allows you to clone a bot with a new configuration')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd, actions) => undefined);
 program.parse(process.argv);
 
 console.error('not implemented yet');

--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -44,9 +44,7 @@ program
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd, actions) => undefined);
 
 const args = <ConnectAzureArgs><any>program.parse(process.argv);
 

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -38,9 +38,7 @@ program
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd, actions) => undefined);
 
 const args = <ConnectLuisArgs><any>program.parse(process.argv);
 

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -38,9 +38,7 @@ program
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd, actions) => undefined);
 
 const args = <ConnectEndpointArgs><any>program.parse(process.argv);
 

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -37,9 +37,7 @@ program
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd, actions) => undefined);
 
 const args = <ConnectLuisArgs><any>program.parse(process.argv);
 

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -38,9 +38,7 @@ program
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd, actions) => undefined);
 
 program.parse(process.argv);
 

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -14,8 +14,7 @@ program
     .name('msbot export')
     .description('export all of the connected services to local files')
     .option('-bot, -b', 'path to bot file.  If omitted, local folder will look for a .bot file')
-    .action((cmd, actions) => {
-    });
+    .action((cmd, actions) => undefined);
 program.parse(process.argv);
 
 console.error('not implemented yet');

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -22,8 +22,7 @@ program
     .name('msbot list')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
-    .action((cmd, actions) => {
-    });
+    .action((cmd, actions) => undefined);
 
 const parsed = <ListArgs><any>program.parse(process.argv);
 


### PR DESCRIPTION
Related to #313

## Proposed Changes
  - Replaced empty brackets with `undefined` in order to fix the 'no-empty' warnings from TSLint in MSBot.

## Testing
Travis will no longer report this issue