### PR TITLE
Fixed TSLint 'max-line-length' warnings in MSBot

### DIFF
--- a/packages/MSBot/src/models/botConfigModel.ts
+++ b/packages/MSBot/src/models/botConfigModel.ts
@@ -2,7 +2,15 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
-import { IAzureBotService, IBotConfig, IConnectedService, IDispatchService, IEndpointService, IFileService, ILuisService, IQnAService, ServiceType } from '../schema';
+import { IAzureBotService,
+    IBotConfig,
+    IConnectedService,
+    IDispatchService,
+    IEndpointService,
+    IFileService,
+    ILuisService,
+    IQnAService,
+    ServiceType } from '../schema';
 import { AzureBotService } from './azureBotService';
 import { ConnectedService } from './connectedService';
 import { DispatchService } from './dispatchService';

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -30,7 +30,8 @@ program
     .option('-n, --name <name>', 'name for the LUIS app')
     .option('-a, --appId <appid>', 'AppId for the LUIS App')
     .option('-v, --version <version>', 'version for the LUIS App, (example: v0.1)')
-    .option('--authoringKey <authoringkey>', 'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
+    .option('--authoringKey <authoringkey>',
+            'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
     .option('--subscriptionKey <subscriptionKey>', '(OPTIONAL) subscription key used for querying a LUIS model\n')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -30,8 +30,10 @@ program
     .description('Connect the bot to a QnA knowledgebase')
     .option('-n, --name <name>', 'name for the QNA knowledgebase')
     .option('-k, --kbId <kbId>', 'QnA Knowledgebase Id ')
-    .option('--subscriptionKey <subscriptionKey>', 'Azure Cognitive Service subscriptionKey/accessKey for calling the QnA management API (from azure portal)')
-    .option('--endpointKey <endpointKey>', 'endpointKey for calling the QnA service (from https://qnamaker.ai portal or qnamaker list endpointkeys command)')
+    .option('--subscriptionKey <subscriptionKey>',
+            'Azure Cognitive Service subscriptionKey/accessKey for calling the QnA management API (from azure portal)')
+    .option('--endpointKey <endpointKey>',
+            'endpointKey for calling the QnA service (from https://qnamaker.ai portal or qnamaker list endpointkeys command)')
     .option('--hostname <url>', 'url for private QnA service (example: https://myqna.azurewebsites.net)')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -62,7 +62,7 @@ if (!args.quiet) {
     }
 
     while (!args.endpoint || args.endpoint.length == 0) {
-        args.endpoint = readline.question(`What localhost endpoint does your bot use for debugging [Example: http://localhost:3978/api/messages]? `, {
+        args.endpoint = readline.question(`What endpoint does your bot use for debugging [Example: http://localhost:3978/api/messages]? `, {
             defaultInput: `http://localhost:3978/api/messages`
         });
     }


### PR DESCRIPTION
Related to #313

## Proposed Changes
  - Several lines were split for fixing the 'max-line-length' warnings from TSLint in MSBot.

## Testing
Travis will no longer report this issue