### PR TITLE
Fixed 'no-console' TSLint warnings.

### DIFF
--- a/packages/MSBot/src/msbot-clone.ts
+++ b/packages/MSBot/src/msbot-clone.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 

--- a/packages/MSBot/src/msbot-connect-azure.ts
+++ b/packages/MSBot/src/msbot-connect-azure.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as path from 'path';

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fs from 'fs-extra';

--- a/packages/MSBot/src/msbot-connect.ts
+++ b/packages/MSBot/src/msbot-connect.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 

--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as fsx from 'fs-extra';

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -2,6 +2,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import { BotConfig } from './BotConfig';

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -3,6 +3,7 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+// tslint:disable:no-console
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';


### PR DESCRIPTION
Related to #313

## Proposed Changes
  - The 'no-console' rule was disabled in some files located in MSBot\src\. These files correspond to a console functionality , so the commands console.error are needed.

## Testing
Travis will no longer report this issue