### PR TITLE
Fixed TSLint 'prefer-const' warnings in MSBot

### DIFF
--- a/packages/MSBot/src/models/botConfigModel.ts
+++ b/packages/MSBot/src/models/botConfigModel.ts
@@ -51,7 +51,9 @@ export class BotConfigModel implements Partial<IBotConfig> {
     }
 
     public static fromJSON(source: Partial<IBotConfig> = {}): BotConfigModel {
-        let { name = '', description = '', secretKey = '', services = [] } = source;
+        const { description = '', secretKey = '', name = '' } = source;
+        let { services = [] } = source;
+
         services = services.slice().map(BotConfigModel.serviceFromJSON);
         const botConfig = new BotConfigModel();
         Object.assign(botConfig, { services, description, name, secretKey });

--- a/packages/MSBot/src/models/qnaMakerService.ts
+++ b/packages/MSBot/src/models/qnaMakerService.ts
@@ -15,7 +15,8 @@ export class QnaMakerService extends ConnectedService implements IQnAService {
 
     constructor(source: IQnAService = {} as IQnAService) {
         super(source);
-        let { id = '', name = '', kbId = '', subscriptionKey = '', endpointKey = '', hostname = '' } = source;
+        const { name = '', kbId = '', subscriptionKey = '', endpointKey = ''} = source;
+        let { id = '', hostname = ''} = source;
         this.id = kbId;
         if (hostname) {
             hostname = url.resolve(hostname, '/qnamaker');

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -28,7 +28,7 @@ program
     });
 
 const args: SecretArgs = <SecretArgs><any>program.parse(process.argv);
-let path: string;
+const path: string = '';
 
 if (process.argv.length < 3) {
     showErrorHelp();


### PR DESCRIPTION
Related to #313

## Proposed Changes
  - Modified declarations when const was preferred instead of let as suggested by TSLint.

## Testing
Travis will no longer report this issue