### PR TITLE
Fix TSLint warnings in msbot-connect.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect.ts
+++ b/packages/MSBot/src/msbot-connect.ts
@@ -6,7 +6,7 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = (): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
@@ -24,17 +24,17 @@ program
     .command('luis', 'connect to a LUIS application')
     .command('qna', 'connect to QNA a service');
 
-const args = program.parse(process.argv);
+const args: program.Command = program.parse(process.argv);
 
 // args should be undefined is subcommand is executed
 if (args) {
-    const a = process.argv.slice(2);
+    const a: string[] = process.argv.slice(2);
     console.error(chalk.default.redBright(`Unknown arguments: ${a.join(' ')}`));
     showErrorHelp();
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
 
         return '';


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following warnings in the file `msbot-connect.ts`:
- `typedef`
- `no-any`

## Testing
Travis will no longer report this issue.