### PR TITLE
Fix TSLint warnings in msbot-init.ts

### DIFF
--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -9,12 +9,12 @@ import * as program from 'commander';
 import * as fsx from 'fs-extra';
 import * as readline from 'readline-sync';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     program.help();
 };
 
-interface InitArgs {
+interface IInitArgs {
     name: string;
     description: string;
     secret: boolean;
@@ -22,6 +22,7 @@ interface InitArgs {
     appId: string;
     appPassword: string;
     quiet: boolean;
+    [key: string]: string | boolean;
 }
 
 program
@@ -32,50 +33,66 @@ program
     .option('-e, --endpoint <endpoint>', 'local endpoint for the bot')
     .option('--secret', 'generate a secret and encrypt service keys with it')
     .option('-q, --quiet', 'do not prompt')
-    .action((name, x) => {
+    .action((name: program.Command, x: program.Command) => {
         console.log(name);
     });
 
-let args: InitArgs = <InitArgs><any>program.parse(process.argv);
+const args: IInitArgs = {
+    name: '',
+    description: '',
+    secret: false,
+    endpoint: '',
+    appId: '',
+    appPassword: '',
+    quiet: false
+};
 
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 if (!args.quiet) {
 
-    let exists = fsx.existsSync(`${args.name}.bot`);
-    while (((!args.hasOwnProperty('name') || args.name.length == 0)) || exists) {
-        if (exists)
+    let exists: boolean = fsx.existsSync(`${args.name}.bot`);
+    while (((!args.hasOwnProperty('name') || args.name.length === 0)) || exists) {
+        if (exists) {
             console.log(`${args.name}.bot already exists`);
+        }
         args.name = readline.question(`What name would you like for your bot? `);
         exists = fsx.existsSync(`${args.name}.bot`);
     }
 
-    while (!args.endpoint || args.endpoint.length == 0) {
-        args.endpoint = readline.question(`What localhost endpoint does your bot use for debugging [Example: http://localhost:3978/api/messages]? `, {
+    while (!args.endpoint || args.endpoint.length === 0) {
+        args.endpoint = readline.question(`What endpoint does your bot use for debugging [Example: http://localhost:3978/api/messages]? `, {
             defaultInput: `http://localhost:3978/api/messages`
         });
     }
 
-    if (!args.appId || args.appId.length == 0) {
-        const answer = readline.question(`Do you have an appId for endpoint? [no] `, {
+    if (!args.appId || args.appId.length === 0) {
+        const answer: string = readline.question(`Do you have an appId for endpoint? [no] `, {
             defaultInput: 'no'
         });
-        if (answer == 'y' || answer == 'yes') {
+        if (answer === 'y' || answer === 'yes') {
             args.appId = readline.question(`What is your appId for ${args.endpoint}? [none] `, {
                 defaultInput: ''
             });
         }
     }
 
-    while (args.appId && args.appId.length > 0 && (!args.appPassword || args.appPassword.length == 0)) {
+    while (args.appId && args.appId.length > 0 && (!args.appPassword || args.appPassword.length === 0)) {
         args.appPassword = readline.question(`What is your appPassword for ${args.endpoint}? `, {
             defaultInput: ''
         });
     }
 
     if (!args.secret) {
-        const answer = readline.question(`=== Your bot file contains service keys and we strongly recommend you encrypt them to keep them safe. ===\nWould you like to encrypt your keys with a secret? [yes] `, {
+        // tslint:disable-next-line:max-line-length
+        const answer: string = readline.question(`=== Your bot file contains service keys and we strongly recommend you encrypt them to keep them safe. ===\nWould you like to encrypt your keys with a secret? [yes] `, {
             defaultInput: 'yes'
         });
-        args.secret = answer == 'y' || answer == 'yes';
+        args.secret = answer === 'y' || answer === 'yes';
     }
 }
 
@@ -87,9 +104,8 @@ if (args.secret) {
 
 if (!args.name) {
     console.error('missing --name argument');
-}
-else {
-    const bot = new BotConfiguration();
+} else {
+    const bot: BotConfiguration = new BotConfiguration();
     bot.name = args.name;
     bot.description = args.description;
 
@@ -100,19 +116,26 @@ else {
         appPassword: args.appPassword || ''
     }));
 
-    let filename = bot.name + '.bot';
+    const filename: string = `${bot.name}.bot`;
     bot.saveAs(filename, secret);
-    let result = {
+    const result: IResult = {
         status: 'OK',
         file: filename,
         secret: secret
     };
-    if (args.quiet)
+    if (args.quiet) {
         console.log(JSON.stringify(result, null, 2));
-    else {
+    } else {
         console.log(`created ${filename}`);
         if (secret) {
+            // tslint:disable-next-line:max-line-length
             console.log(`Your bot is encrypted with secret:\n${secret}\n\nPlease save this secret in a secure place to keep your keys safe.`);
         }
     }
+}
+
+interface IResult {
+    status: string;
+    file: string;
+    secret: string | undefined;
 }


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following warnings in the file `msbot-init.ts`:
- `typedef`
- `no-any`
- `prefer-const`
- `triple-equals`
- `curly`
- `max-line-length`
- `one-line`
- `prefer-template`

## Testing
Travis will no longer report this issue.