### PR TITLE
Fix TSLint warnings in msbot-connect-qna.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -11,16 +11,17 @@ import * as txtfile from 'read-text-file';
 import * as validurl from 'valid-url';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ConnectQnaArgs extends IQnAService {
+interface IConnectQnaArgs extends IQnAService {
     bot: string;
     secret: string;
     stdin: boolean;
     input?: string;
+    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -28,21 +29,37 @@ program
     .description('Connect the bot to a QnA knowledgebase')
     .option('-n, --name <name>', 'name for the QNA knowledgebase')
     .option('-k, --kbId <kbId>', 'QnA Knowledgebase Id ')
-    .option('--subscriptionKey <subscriptionKey>', 'Azure Cognitive Service subscriptionKey/accessKey for calling the QnA management API (from azure portal)')
-    .option('--endpointKey <endpointKey>', 'endpointKey for calling the QnA service (from https://qnamaker.ai portal or qnamaker list endpointkeys command)')
+    .option('--subscriptionKey <subscriptionKey>',
+            'Azure Cognitive Service subscriptionKey/accessKey for calling the QnA management API (from azure portal)')
+    .option('--endpointKey <endpointKey>',
+            'endpointKey for calling the QnA service (from https://qnamaker.ai portal or qnamaker list endpointkeys command)')
     .option('--hostname <url>', 'url for private QnA service (example: https://myqna.azurewebsites.net)')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
-
-    });
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
 program.parse(process.argv);
 
-let args = <ConnectQnaArgs><any>program.parse(process.argv);
+const args: IConnectQnaArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    subscriptionKey: '',
+    kbId: '',
+    hostname: '',
+    endpointKey: '',
+    name: ''
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (process.argv.length < 3) {
     program.help();
@@ -50,14 +67,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectQnaArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfiguration.load(args.bot, args.secret)
             .then(processConnectQnaArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -69,44 +86,48 @@ async function processConnectQnaArgs(config: BotConfiguration): Promise<BotConfi
 
     if (args.stdin) {
         Object.assign(args, JSON.parse(await getStdin()));
-    }
-    else if (args.input != null) {
+    } else if (args.input != null) {
         Object.assign(args, JSON.parse(await txtfile.read(<string>args.input)));
     }
 
-    if (!args.kbId || !uuidValidate(args.kbId))
+    if (!args.kbId || !uuidValidate(args.kbId)) {
         throw new Error('bad or missing --kbId');
+    }
 
-    if (!args.hasOwnProperty('name'))
+    if (!args.hasOwnProperty('name')) {
         throw new Error('missing --name');
+    }
 
-    if (!args.subscriptionKey || !uuidValidate(args.subscriptionKey))
+    if (!args.subscriptionKey || !uuidValidate(args.subscriptionKey)) {
         throw new Error('bad or missing --subscriptionKey');
-
-    if (!args.endpointKey || !uuidValidate(args.endpointKey))
+        }
+    if (!args.endpointKey || !uuidValidate(args.endpointKey)) {
         throw new Error('bad or missing --endpointKey');
-
-    if (!args.hostname || !validurl.isWebUri(args.hostname))
+        }
+    if (!args.hostname || !validurl.isWebUri(args.hostname)) {
         throw new Error('bad or missing --hostname');
+        }
 
     // add the service
-    let newService = new QnaMakerService({
+    const newService: QnaMakerService = new QnaMakerService({
         name: args.name,
         kbId: args.kbId,
         subscriptionKey: args.subscriptionKey,
         endpointKey: args.endpointKey,
         hostname: args.hostname
     });
-    let id = config.connectService(newService);
+    const id: string = config.connectService(newService);
 
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
+
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following warnings in the file `msbot-connect-qna.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `max-line-length`
- `no-empty`
- `prefer-const`
- `one-line`
- `curly`
- `newline-before-return`
- `eofline`

## Testing
Travis will no longer report this issue.