### PR TITLE
Fix TSLint warnings in msbot-get.ts

### DIFF
--- a/packages/MSBot/src/msbot-get.ts
+++ b/packages/MSBot/src/msbot-get.ts
@@ -3,67 +3,79 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
-import { BotConfiguration } from 'botframework-config';
+import { BotConfiguration, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ListArgs {
+interface IListArgs {
     bot: string;
     secret: string;
     service: string;
     args: string[];
+    [key: string]: string | string[];
 }
 
 program
     .name('msbot get <serviceNameOrId>')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
-    .action((cmd, actions) => {
-    });
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
-let args = <ListArgs><any>program.parse(process.argv);
+const args: IListArgs = {
+    bot: '',
+    secret: '',
+    service: '',
+    args: []
+};
+
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 
 if (!args.bot) {
     BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
         .then(processListArgs)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 } else {
     BotConfiguration.load(args.bot, args.secret)
         .then(processListArgs)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 }
-
 
 async function processListArgs(config: BotConfiguration): Promise<BotConfiguration> {
 
     if (args.args.length < 2) {
         throw new Error('missing the service id or name');
     }
-    let nameOrId = args.args[0];
-    var service = config.findServiceByNameOrId(nameOrId);
+    const nameOrId: string = args.args[0];
+    const service: IConnectedService = config.findServiceByNameOrId(nameOrId);
     if (service == null) {
         throw new Error(`${nameOrId} was not found in ${config.getPath()}`);
     }
     console.log(JSON.stringify(service, null, 4));
+
     return config;
 }
 
-function showErrorHelp()
-{
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following warnings in the file `msbot-get.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `no-empty`
- `prefer-const`
- `no-consecutive-blank-lines`
- `no-var-keyword`
- `newline-before-return`
- `one-line`
- `eofline`

## Testing
Travis will no longer report this issue.