### PR TITLE
Fix TSLint warnings in msbot-connect-endpoint.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -45,18 +45,11 @@ const args: IConnectEndpointArgs = {
     appId: '',
     appPassword: '',
     endpoint: '',
-    tenantId: '',
-    subscriptionId: '',
-    resourceGroup: '',
     name: ''
 };
 
 const commands: program.Command = program.parse(process.argv);
-for (const i of commands.args) {
-    if (args.hasOwnProperty(i)) {
-        args[i] = commands[i];
-    }
-}
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     showErrorHelp();


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following warnings in the file `msbot-connect-endpoint.ts`:
- `typedef`
- `no-any`
- `no-trailing-whitespace`
- `interface-name`
- `no-empty`
- `prefer-const`
- `one-line`
- `curly`
- `triple-equals`
- `no-object-literal-type-assertion`
- `space-within-parens`
- `newline-before-return`
- `eofline`


## Testing
Travis will no longer report this issue.