### PR TITLE
Fix TSLint warnings in msbot-connect-luis.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -10,16 +10,17 @@ import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = (): void => {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ConnectLuisArgs extends ILuisService {
+interface IConnectLuisArgs extends ILuisService {
     bot: string;
     secret: string;
     stdin: boolean;
     input?: string;
+    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -29,33 +30,48 @@ program
     .option('-a, --appId <appid>', 'AppId for the LUIS App')
     .option('-v, --version <version>', 'version for the LUIS App, (example: v0.1)')
     .option('-r, --region <region>', 'region for the LUIS App, (default:westus)')
-    .option('--authoringKey <authoringkey>', 'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
+    .option('--authoringKey <authoringkey>',
+            'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
     .option('--subscriptionKey <subscriptionKey>', '(OPTIONAL) subscription key used for querying a LUIS model\n')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
-    });
+const args: IConnectLuisArgs = {
+    bot: '',
+    secret: '',
+    stdin: true,
+    appId: '',
+    authoringKey: '',
+    subscriptionKey: '',
+    version: '',
+    region: '',
+    name: ''
+};
 
-let args = <ConnectLuisArgs><any>program.parse(process.argv);
-
+const commands: program.Command = program.parse(process.argv);
+for (const i of commands.args) {
+    if (args.hasOwnProperty(i)) {
+        args[i] = commands[i];
+    }
+}
 if (process.argv.length < 3) {
     program.help();
 } else {
     if (!args.bot) {
         BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectLuisArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfiguration.load(args.bot, args.secret)
             .then(processConnectLuisArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -68,31 +84,35 @@ async function processConnectLuisArgs(config: BotConfiguration): Promise<BotConf
 
     if (args.stdin) {
         Object.assign(args, JSON.parse(await getStdin()));
-    }
-    else if (args.input) {
+    } else if (args.input) {
         Object.assign(args, JSON.parse(await txtfile.read(<string>args.input)));
     }
 
-    if (!args.hasOwnProperty('name'))
+    if (!args.hasOwnProperty('name')) {
         throw new Error('Bad or missing --name');
+    }
 
-    if (!args.appId || !uuidValidate(args.appId))
+    if (!args.appId || !uuidValidate(args.appId)) {
         throw new Error('bad or missing --appId');
+    }
 
-    if (!args.version)
+    if (!args.version) {
         throw new Error('bad or missing --version');
+    }
 
-    if (!args.authoringKey || !uuidValidate(args.authoringKey))
+    if (!args.authoringKey || !uuidValidate(args.authoringKey)) {
         throw new Error('bad or missing --authoringKey');
+    }
 
-    if (!args.region || args.region.length == 0)
-        args.region = "westus";
+    if (!args.region || args.region.length === 0) {
+        args.region = 'westus';
+    }
 
     //if (!args.subscriptionKey || !uuidValidate(args.subscriptionKey))
     //    throw new Error("bad or missing --subscriptionKey");
 
     // add the service
-    let newService = new LuisService({
+    const newService: LuisService = new LuisService({
         name: args.name,
         appId: args.appId,
         version: args.version,
@@ -100,15 +120,17 @@ async function processConnectLuisArgs(config: BotConfiguration): Promise<BotConf
         subscriptionKey: args.subscriptionKey,
         region: args.region
     });
-    let id = config.connectService(newService);
+    const id: string = config.connectService(newService);
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
+
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -53,11 +53,8 @@ const args: IConnectLuisArgs = {
 };
 
 const commands: program.Command = program.parse(process.argv);
-for (const i of commands.args) {
-    if (args.hasOwnProperty(i)) {
-        args[i] = commands[i];
-    }
-}
+Object.assign(args, commands);
+
 if (process.argv.length < 3) {
     program.help();
 } else {


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following warnings in the file `msbot-connect-luis.ts`:
- `typedef`
- `no-any`
- `interface-name`
- `max-line-length`
- `no-empty`
- `prefer-const`
- `one-line`
- `curly`
- `triple-equals`
- `quotemark`
- `newline-before-return`
- `eofline`

## Testing
Travis will no longer report this issue.