### PR TITLE
Fix TSLint warnings in msbot-connect-blob.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-blob.ts
+++ b/packages/MSBot/src/msbot-connect-blob.ts
@@ -10,16 +10,18 @@ import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { uuidValidate } from './utils';
 
-program.Command.prototype.unknownOption = function (flag: any) {
-    console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
+program.Command.prototype.unknownOption = function (): void {
+    console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
     showErrorHelp();
 };
 
-interface ConnectBlobArgs extends IBlobStorageService {
+interface IConnectBlobArgs extends IBlobStorageService {
     bot: string;
     secret: string;
     stdin: boolean;
     input?: string;
+    // tslint:disable-next-line:no-any
+    [key: string]: any;
 }
 
 program
@@ -31,17 +33,31 @@ program
     .option('-r, --resourceGroup <resourceGroup>', 'Azure resource group name')
     .option('--serviceName <serviceName>', 'Azure service name')
     .option('--connectionString <connectionString>', 'Blob storage connection string')
-    .option('-c, --container <container>', "blob container name")
+    .option('-c, --container <container>', 'blob container name')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')
     .option('--stdin', 'arguments are passed in as JSON object via stdin')
-    .action((cmd, actions) => {
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 
-    });
+const commands: program.Command = program.parse(process.argv);
+const args: IConnectBlobArgs = {
+    bot: '',
+    secret: '',
+    stdin: false,
+    connectionString: '',
+    container: '',
+    tenantId: '',
+    subscriptionId: '',
+    resourceGroup: '',
+    serviceName: '',
+    name: ''
+};
 
-let args = <ConnectBlobArgs><any>program.parse(process.argv);
+for (const key of args.keys) {
+    args[key] = commands[key];
+}
 
 if (process.argv.length < 3) {
     program.help();
@@ -49,14 +65,14 @@ if (process.argv.length < 3) {
     if (!args.bot) {
         BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
             .then(processConnectAzureArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
     } else {
         BotConfiguration.load(args.bot, args.secret)
             .then(processConnectAzureArgs)
-            .catch((reason) => {
+            .catch((reason: Error) => {
                 console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
                 showErrorHelp();
             });
@@ -66,31 +82,29 @@ if (process.argv.length < 3) {
 async function processConnectAzureArgs(config: BotConfiguration): Promise<BotConfiguration> {
     if (args.stdin) {
         Object.assign(args, JSON.parse(await getStdin()));
-    }
-    else if (args.input != null) {
+    } else if (args.input != null) {
         Object.assign(args, JSON.parse(await txtfile.read(<string>args.input)));
     }
 
-    if (!args.serviceName || args.serviceName.length == 0)
-        throw new Error('Bad or missing --serviceName');
+    if (!args.serviceName || args.serviceName.length === 0) {
+        throw new Error('Bad or missing --serviceName'); }
 
-    if (!args.tenantId || args.tenantId.length == 0)
-        throw new Error('Bad or missing --tenantId');
+    if (!args.tenantId || args.tenantId.length === 0) {
+        throw new Error('Bad or missing --tenantId'); }
 
-    if (!args.subscriptionId || !uuidValidate(args.subscriptionId))
-        throw new Error('Bad or missing --subscriptionId');
+    if (!args.subscriptionId || !uuidValidate(args.subscriptionId)) {
+        throw new Error('Bad or missing --subscriptionId'); }
 
-    if (!args.resourceGroup || args.resourceGroup.length == 0)
-        throw new Error('Bad or missing --resourceGroup');
+    if (!args.resourceGroup || args.resourceGroup.length === 0) {
+        throw new Error('Bad or missing --resourceGroup'); }
 
-    if (!args.connectionString || args.connectionString.length == 0)
-        throw new Error('Bad or missing --connectionString');
+    if (!args.connectionString || args.connectionString.length === 0) {
+        throw new Error('Bad or missing --connectionString'); }
 
-    if (!args.container || args.container.length == 0)
-        throw new Error('Bad or missing --container');
+    if (!args.container || args.container.length === 0) {
+        throw new Error('Bad or missing --container'); }
 
-    let services = [];
-    let service = new BlobStorageService({
+    const service: BlobStorageService = new BlobStorageService({
         name: args.hasOwnProperty('name') ? args.name : args.serviceName,
         serviceName: args.serviceName,
         tenantId: args.tenantId,
@@ -99,15 +113,17 @@ async function processConnectAzureArgs(config: BotConfiguration): Promise<BotCon
         connectionString: args.connectionString,
         container: args.container
     });
-    let id = config.connectService(service);
+    const id: string = config.connectService(service);
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
+
     return config;
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-connect-blob.ts
+++ b/packages/MSBot/src/msbot-connect-blob.ts
@@ -54,10 +54,7 @@ const args: IConnectBlobArgs = {
     serviceName: '',
     name: ''
 };
-
-for (const key of args.keys) {
-    args[key] = commands[key];
-}
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     program.help();


### PR DESCRIPTION
Related to #313

## Proposed Changes
The following TSLint issues have been fixed:

- `typedef`
- `no-any`
- `interface-name`
- `quotemark`
- `no-empty`
- `prefer-const`
- `one-line`
- `curly`
- `triple-equals`
- `newline-before-return`
- `eofline`

A key had to be added to `IConnectGenericArgs` to be able to iterate through its properties. The type of the key had to be `any` to avoid conflict with `for (const key of args.keys)`. An exception for `no-any` has been added to that particular line.
## Testing
Travis will no longer report this issue.