### PR TITLE
Fix TSLint warnings in msbot-generic.ts

### DIFF
--- a/packages/MSBot/src/msbot-connect-generic.ts
+++ b/packages/MSBot/src/msbot-connect-generic.ts
@@ -47,10 +47,7 @@ const args: IConnectGenericArgs = {
     configuration: { '': '' },
     name: ''
 };
-
-for (const key of args.keys) {
-    args[key] = commands[key];
-}
+Object.assign(args, commands);
 
 if (process.argv.length < 3) {
     program.help();


### PR DESCRIPTION
Related to #313

## Proposed Changes
The following TSLint issues have been fixed in `msbot-generic.ts`
- typedef
- no-any
- interface-name
- curly
- prefer-const
- no-var-keyword
- forin
- newline-before-return
- eofline

A key had to be added to `IConnectGenericArgs` to be able to iterate through its properties.
## Testing
Travis will no longer report this issue.