### PR TITLE
Fix TSLint warnings in msbot.ts

### DIFF
--- a/packages/MSBot/package-lock.json
+++ b/packages/MSBot/package-lock.json
@@ -34,6 +34,12 @@
       "integrity": "sha1-6sVaOdWjSZEgYsnlIWzVUMB/2cg=",
       "dev": true
     },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "http://bbnpm.azurewebsites.net/@types%2fuuid/-/uuid-3.4.3.tgz",

--- a/packages/MSBot/package.json
+++ b/packages/MSBot/package.json
@@ -37,6 +37,7 @@
     "@types/readline-sync": "^1.4.3",
     "@types/uuid": "^3.4.3",
     "@types/valid-url": "^1.0.2",
+    "@types/semver": "^5.5.0",
     "mocha": "^5.2.0"
   },
   "dependencies": {

--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -7,18 +7,19 @@
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
+import * as semver from 'semver';
 
-const pkg = require('../package.json');
-const semver = require('semver');
-const requiredVersion = pkg.engines.node;
+// tslint:disable-next-line:no-var-requires no-require-imports
+const pkg: IPackage = require('../package.json');
+const requiredVersion: string = pkg.engines.node;
 if (!semver.satisfies(process.version, requiredVersion)) {
     console.error(`Required node version ${requiredVersion} not satisfied with current version ${process.version}.`);
     process.exit(1);
 }
 
-program.Command.prototype.unknownOption = function (flag: any) {
+program.Command.prototype.unknownOption = function (): void {
     console.error(chalk.default.redBright(`Unknown arguments: ${process.argv.slice(2).join(' ')}`));
-    program.outputHelp((str) => {
+    program.outputHelp((str: string) => {
         console.error(str);
 
         return '';
@@ -54,16 +55,21 @@ program
 program
     .command('disconnect <service>', 'disconnect from a resource used by the bot');
 
-const args = program.parse(process.argv);
+const args: program.Command = program.parse(process.argv);
 
 // args should be undefined is subcommand is executed
 if (args) {
-    const a = process.argv.slice(2);
-    console.error(chalk.default.redBright(`Unknown arguments: ${a.join(' ')}`));
-    program.outputHelp((str) => {
+    const unknownArgs: string[] = process.argv.slice(2);
+    console.error(chalk.default.redBright(`Unknown arguments: ${unknownArgs.join(' ')}`));
+    program.outputHelp((str: string) => {
         console.error(str);
 
         return '';
     });
     process.exit(1);
+}
+
+interface IPackage {
+    version: string;
+    engines: { node: string };
 }


### PR DESCRIPTION
Related to #313

## Proposed Changes
The following rules have been fixed:
- typedef
- no-require-imports
- no-var-requires
- no-any

To fix `no-var-require`, a dependecy for `semver` was added in package.json.

To fix `no-any` for const `pkg`, a new interface was added.

The variable `a` was renamed to `unknownArgs`.

## Testing
Travis will no longer report this issue.