### PR TITLE
Fix #408: duplicated json output on import app

### DIFF
--- a/packages/LUIS/bin/luis
+++ b/packages/LUIS/bin/luis
@@ -110,6 +110,8 @@ async function runProgram() {
                 case "application":
                     result = await client.apps.add(args.region, requestBody, args);
                     result = await client.apps.get(args.region, result, args);
+
+                    // Write output to console and return
                     writeAppToConsole(config, args, requestBody, result);
                     return;
                 case "closedlist":
@@ -276,6 +278,8 @@ async function runProgram() {
                 case "app":
                 case "application":
                     result = await client.apps.get(args.region, args.appId, args);
+
+                    // Write output to console and return
                     writeAppToConsole(config, args, requestBody, result);
                     return;
 
@@ -358,8 +362,10 @@ async function runProgram() {
                 case "application":
                     result = await client.apps.importMethod(args.region, requestBody, args);
                     result = await client.apps.get(args.region, result, args);
+
+                    // Write output to console and return
                     writeAppToConsole(config, args, requestBody, result);
-                    break;
+                    return;
 
                 case "version":
                     result = await client.versions.importMethod(args.region, args.appId, requestBody, args);


### PR DESCRIPTION
Fixes #408

## Proposed Changes
  - Replace `break` with `return` after outputting json result.
  - Add comment `// Write output to console and return` on each occurrence

## Testing
```
$str = luis import application --in "" --appName "" --authoringKey "" --endpointBasePath ""
$json = "$str".Substring(0, "$str".Length / 2) | ConvertFrom-Json
```