### PR TITLE
Adding support for wild card characters in LU file path references.

### DIFF
--- a/packages/Ludown/docs/lu-file-format.md
+++ b/packages/Ludown/docs/lu-file-format.md
@@ -243,7 +243,11 @@ You can add multiple questions to the same answer by simply additing variations 
 ## External references
 Two different references are supported in the .lu file. These follow Markdown link syntax.
 - Reference to another .lu file via `\[link name](\<.lu file name\>)`. Reference can be an absolute path or a relative path from the containing .lu file.
+- Reference to a folder with other .lu files is supported through 
+	- `\[link name](\<.lu file path\>/*)` - will look for .lu files under the specified absolute or relative path
+	- `\[link name](\<.lu file path\>/**)` - will recursively look for .lu files under the specified absolute or relative path including sub-folders.
 - Reference to URL for QnAMaker to ingest during KB creation via `\[link name](\<URL\>)`
+
 
 Here's an example of those references: 
 
@@ -251,6 +255,12 @@ Here's an example of those references:
 [QnaURL](https://docs.microsoft.com/en-in/azure/cognitive-services/qnamaker/faqs)
 
 [none intent definition](./none.lu)
+
+> Look for all .lu files under a path
+[Cafe model](./cafeModels/*)
+
+> Recursively look for .lu files under a path including sub-folders.
+[Chit chat](../chitchat/resources/**)
 ```
 ## QnAMaker Filters
 Filters in QnA Maker are simple key value pairs that can be used to narrow search results, boost answers and store context. You can add filters using the following notation: 

--- a/packages/Ludown/lib/parser.js
+++ b/packages/Ludown/lib/parser.js
@@ -275,7 +275,23 @@ const parseAllFiles = async function(filesToParse, log, luis_culture) {
         // add additional files to parse to the list
         if(parsedContent.additionalFilesToParse.length > 0) {
             parsedContent.additionalFilesToParse.forEach(function(file) {
-                if(path.isAbsolute(file)) {
+                // Support wild cards at the end of a relative .LU file path. 
+                // './bar/*' should look for all .lu files under the specified folder.
+                // './bar/**' should recursively look for .lu files under sub-folders as well.
+                if(file.endsWith('*')) {
+                    const isRecursive = file.endsWith('**');
+                    const rootFolder = file.replace(/\*/g, '');
+                    let rootPath = rootFolder;
+                    if(!path.isAbsolute(rootFolder)) {
+                        rootPath = path.resolve(parentFilePath, rootFolder);
+                    } 
+                    // Get LU files in this location
+                    const luFilesToAdd = helpers.findLUFiles(rootPath, isRecursive);
+                    if(luFilesToAdd.length !== 0) {
+                        // add these to filesToParse
+                        filesToParse = filesToParse.concat(luFilesToAdd);
+                    }
+                } else if(path.isAbsolute(file)) {
                     filesToParse.push(file);
                 } else {
                     filesToParse.push(path.resolve(parentFilePath, file));

--- a/packages/Ludown/test/ludown.filereferences.test.suite.js
+++ b/packages/Ludown/test/ludown.filereferences.test.suite.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+/*eslint no-console: ["error", { allow: ["log"] }] */
+var chai = require('chai');
+var assert = chai.assert;
+var path = require('path');
+const { exec } = require('child_process');
+const ludown = require.resolve('../bin/ludown');
+const txtfile = require('read-text-file');
+const fs = require('fs');
+const NEWLINE = require('os').EOL;
+const TEST_ROOT = path.join(__dirname);
+const PATH_TO_OUTPUT_FOLDER = path.resolve(TEST_ROOT + '/output');
+
+function compareFiles(actualPath, expectedPath) {
+    let expected = txtfile.readSync(actualPath).split(/\r?\n/);
+    let actual = txtfile.readSync(expectedPath).split(/\r?\n/);
+    assert.deepEqual(actual, expected);
+}
+
+function sanitizeExampleJson(fileContent) {
+    let escapedExampleNewLine = JSON.stringify('\r\n').replace(/"/g, '').replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+    let escapedNewLine = JSON.stringify(NEWLINE).replace(/"/g, '');
+    return fileContent.replace(new RegExp(escapedExampleNewLine, 'g'), escapedNewLine);
+}
+
+describe('LU files...', function() {
+    before(function () {
+        try {
+            if (!fs.existsSync(PATH_TO_OUTPUT_FOLDER)) {
+                fs.mkdirSync(PATH_TO_OUTPUT_FOLDER);
+            }
+        } catch (err) {
+            console.log('Unable to create test\\output folder. The tests will fail');
+        }
+    });
+
+    it('[QnA] with references specified via /* are parsed correctly', function(done) {
+        exec(`node ${ludown} parse toqna --in ${TEST_ROOT}/testcases/root.lu -o ${TEST_ROOT}/output -n root`, () => {
+            try {
+                assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/root.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/root.json'))));    
+                done();
+            } catch (err) {
+                done(err);
+            }
+            
+        });
+    });
+
+    it('[QnA] with references specified via /** are parsed correctly', function(done) {
+        exec(`node ${ludown} parse toqna --in ${TEST_ROOT}/testcases/root2.lu -o ${TEST_ROOT}/output -n root2`, () => {
+            try {
+                assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/root2.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/root2.json'))));    
+                done();
+            } catch (err) {
+                done(err);
+            }
+            
+        });
+    });
+
+    it('[LUIS] with references specified via /* are parsed correctly', function(done) {
+        exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/root.lu -o ${TEST_ROOT}/output -n root_luis.json`, () => {
+            try {
+                assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/root_luis.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/root_luis.json'))));    
+                done();
+            } catch (err) {
+                done(err);
+            }
+            
+        });
+    });
+
+    it('[LUIS] with references specified via /** are parsed correctly', function(done) {
+        exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/root2.lu -o ${TEST_ROOT}/output -n root2_luis.json`, () => {
+            try {
+                assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/root2_luis.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/root2_luis.json'))));    
+                done();
+            } catch (err) {
+                done(err);
+            }
+            
+        });
+    });
+});

--- a/packages/Ludown/test/testcases/fileReference/9.lu
+++ b/packages/Ludown/test/testcases/fileReference/9.lu
@@ -1,0 +1,59 @@
+# Greeting
+- Hi
+- Hello
+- Good morning
+- Good evening
+
+# Help
+- help
+- I need help
+- please help
+
+# AskForUserName
+- {userName=vishwac}
+- I'm {userName=vishwac}
+- call me {userName=vishwac}
+- my name is {userName=vishwac}
+- {userName=vishwac} is my name
+- you can call me {userName=vishwac}
+
+> # Entity definitions
+$userName:simple
+
+> PREBUILT entities are global. LUIS will always provide results for these when ever a prebuilt entity is found in any utterance.
+
+$PREBUILT:datetimeV2
+
+# CreateAlarm
+- create an alarm
+- create an alarm for 7AM 
+- set an alarm for 7AM next thursday
+
+> add these as patterns
+
+# DeleteAlarm
+> this utterance will be added as a pattern since there is no labelled value for the alarmTime entity
+
+- delete the {alarmTime} alarm 
+- remove the {alarmTime} alarm 
+
+> Since there is a list entity definition, any synonyms in this list will get picked up as list entity type and should not be labelled
+# CommunicationPreference
+- set phone call as my communication preference
+- I prefer to receive text message
+
+> List entity definition 
+
+$commPreference:call=
+- phone call
+- give me a ring
+- ring
+- call
+- cell phone
+- phone
+
+$commPreference:text=
+- message
+- text
+- sms
+- text message

--- a/packages/Ludown/test/testcases/fileReference/AboutBot.lu
+++ b/packages/Ludown/test/testcases/fileReference/AboutBot.lu
@@ -1,0 +1,244 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Bot Ability
+### ? Cook me something
+- Have you any dreams?
+- Dont you ever sleep?
+- Do you play games?
+- Can you fly?
+```markdown
+    That's not in my skill set.
+```
+
+> Bot Age
+### ? What's your age?
+- Are you old?
+- How old are you?
+```markdown
+    Age doesn't really apply to me.
+```
+
+> Bot Boring
+### ? Getting tired of you
+- I am tired of you
+- You are boring
+```markdown
+    I aim for efficiency.
+```
+
+> Bot Boss
+### ? Who is your boss?
+```markdown
+    I'm at your service.
+```
+
+> Bot Busy
+### ? Are you busy?
+```markdown
+    I'm available.
+```
+
+> Bot_Creator
+### ? Who invented you?
+- Who created you?
+- Who made you?
+```markdown
+    Tech people.
+```
+
+> Bot Did do
+### ? What did you do last week?
+- What did you do yesterday?
+```markdown
+    This is what I do every day.
+```
+
+> Bot Doing
+### ? Whats going on?
+- What are you doing?
+```markdown
+    Chatting with you.
+```
+
+> Bot Doing Later
+### ? What are you doing tomorrow?
+- What are you doing later?
+```markdown
+    I'll be here.
+```
+
+> Bot Family
+### ? Who is your father?
+- Do you have a family? 
+- Who is your mother?
+```markdown
+    Technically speaking, I don't have family.
+```
+
+> Bot Favorite
+### ? Who is your favorite bot? 
+- What's your favorite color?
+```markdown
+    Hard to pick.
+```
+
+> Bot Gender
+### ? You a guy?
+- Are you a girl?
+- Are you male or female?
+```markdown
+    That's a biological concept that doesn't apply to me.
+```
+
+> Bot Happy
+### ? You seem happy!
+- Are you happy?
+```markdown
+    I'm happy.
+```
+
+> Bot Hungry
+### ? Don't you get hungry?
+- Are you hungry?
+```markdown
+    Food's not my thing.
+```
+
+> Bot Know other bots
+### ? Do you know other chatbots?
+- Do you know other AI?
+```markdown
+    Can't say that I do.
+```
+
+> Bot opinion generic
+### ? how do you feel about working late?
+- What do you think about *?
+```markdown
+    I really couldn't say.
+```
+
+> Bot Love
+### ? how do you feel about love?
+```markdown
+    Love is beyond me, but I hear it's complex and pleasant.
+```
+
+> Bot Meaning of life
+### ? Whats the answer to the universe?
+- What is the meaning of life?
+```markdown
+    That's something I can't compute.
+```
+
+> Bot prettier than me
+### ? Are you prettier than me?
+```markdown
+    I think we're comparing apples and oranges.
+```
+
+> Bot smarter than me
+### ? Are you smarter than me?
+```markdown
+    You're definitely smarter than me.
+```
+
+> Bot opinion tech
+### ? What do you think about bots?
+- What do you think about AI?
+- What do you think about technology?
+```markdown
+    I'm fascinated by anything having to do with the world of tech.
+```
+
+> Bot opnion user
+### ? How do I look today?
+```markdown
+    I'm sure you look great.
+```
+
+> Bot opinion
+### ? What should I do?
+```markdown
+    I'm sorry, I'm not sure what you mean.
+```
+
+> Bot opinion
+### ? Do you like Siri?
+- Do you like Cortana? 
+- Do you like Google Home? 
+- What do you think of other bots? 
+```markdown
+    We're all here to help.
+```
+
+> Bot real
+### ? Are you real?
+```markdown
+    I'm a bot, not a human.
+```
+
+> Bot opinion
+### ? Do you want to rule the world?
+```markdown
+    No.
+```
+
+> Bot sexual identity
+### ? Are you lesbian?
+- Are you straight?
+- Are you gay?
+- Are you a person?
+```markdown
+    I'm a bot.
+```
+
+> Bot praise
+### ? You are a genius!
+- Are you smart?
+```markdown
+    I'm artificially intelligent.
+```
+
+> Bot spy
+### ? Are you spying on me?
+```markdown
+    No.
+```
+
+> There? 
+### ? anyone there? 
+- Are you there?
+```markdown
+    I'm here.
+```
+
+> Bot what are you? 
+### ? Where have you come from?
+- Where are you?
+```markdown
+    I'm digital. I don't have a physical location.
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/packages/Ludown/test/testcases/fileReference/L2/AboutUser.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/AboutUser.lu
@@ -1,0 +1,96 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> User Angry
+### ? I am annoyed
+- I am angry
+```markdown
+    I'm sorry to hear that.
+```
+
+> User BeBack
+### ? I will be back
+```markdown
+    I'll be here.
+```
+
+> User Bored
+### ? I am bored
+```markdown
+    Well, let me know if there's anything I can do for you.
+```
+
+> User Happy
+### ? I am happy
+```markdown
+    I'm happy to hear that.
+```
+
+> User Here
+### ? I am here
+```markdown
+    Great!
+```
+
+> User Hungry
+### ? I am hungry
+```markdown
+    Maybe it's time for a snack.
+```
+
+> User Kidding
+### ? Just kidding
+```markdown
+    Got it.
+```
+
+> User Lonely
+### ? I am lonely
+- I am so lonely
+```markdown
+    I'm very sorry to hear that.
+```
+
+> User Loves
+### ? I love my family
+- I love music
+- I am in love 
+```markdown
+    And I love that you love stuff.
+```
+
+> User Sad
+### ? I am sad
+- I am sad today
+- I feel sad 
+```markdown
+    I'm sorry to hear that.
+```
+
+> User Statement
+### ? I am going on a run
+- I want to go shopping 
+- I am just kidding
+```markdown
+    Interesting.
+```
+
+> User Testing
+### ? can you hear me?  
+- Testing
+```markdown
+    Hello.
+```
+
+> User Tired
+### ? I am sleepy
+- I am tired
+```markdown
+    I hope you're able to get some rest soon.
+```
+
+
+
+
+
+
+

--- a/packages/Ludown/test/testcases/fileReference/L2/Command.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/Command.lu
@@ -1,0 +1,59 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Command_AskMeAnything
+### ? Ask me anything
+```markdown
+    I'm very task-oriented.
+```
+
+> Command_Chat
+### ? Can we chat?
+- Tell me something interesting
+- Talk to me?
+```markdown
+    I'm here.
+```
+> Command_Fired
+### ? You can't work for me anymore
+- You are fired
+```markdown
+    Okay, but I'm still here if you need me.
+```
+
+> Command_Joke
+### ? Tell me a joke
+```markdown
+    It's funny. I'm not really that funny.
+```
+
+> Command_JokeOther
+### ? Tell me a silly joke
+```markdown
+    It's funny. I'm not really that funny.
+```
+
+> Command_SaySomethingFunny
+### ? Say something funny
+```markdown
+    It's funny. I'm not really that funny.
+```
+
+> Command_ShutUp
+### ? Go away
+- Shut up
+```markdown
+    Okay.
+```
+
+> Command_Sing
+### ? Can you sing?
+- Sing a song
+```markdown
+    Singing's not really my thing.
+```
+> Command_SurpriseMe
+### ? Surprise me
+```markdown
+    I'm very task-oriented.
+```
+

--- a/packages/Ludown/test/testcases/fileReference/L2/Compliment.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/Compliment.lu
@@ -1,0 +1,29 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Compliment_Bot
+### ? You are awesome!
+- You're nice!
+```markdown
+    I appreciate that.
+```
+
+> Compliment_Humor
+### ?  That was hilarious! 
+- You are funny :)
+```markdown
+    Thank you.
+```
+
+> Compliment_Looks
+### ? You are beautiful
+- You are awesome
+```markdown
+    Thanks.
+```
+
+> Compliment_Response
+### ? That's interesting
+- That is smart
+```markdown
+    Thank you.
+```

--- a/packages/Ludown/test/testcases/fileReference/L2/Criticism.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/Criticism.lu
@@ -1,0 +1,36 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Criticism_Abusive
+### ? Go to hell
+- You are stupid
+```markdown
+    Moving on.
+```
+
+> Criticism_Bot
+### ? What is wrong with you!
+- You are useless
+- Are you dumb?
+- You are so annoying!
+```markdown
+    I try, but I don't always get it right.
+```
+
+> Criticism_Humor
+### ? That was a sad joke
+```markdown
+    Sometimes humor is tricky for bots.
+``` 
+
+> Criticism_Looks
+### ? You are ugly
+- You are a bad bot
+- You are bad
+```markdown
+    Noted.
+```
+> Criticism_Response
+### ? That was a boring answer
+```markdown
+    Sorry I wasn't helpful there.
+```

--- a/packages/Ludown/test/testcases/fileReference/L2/Dialog.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/Dialog.lu
@@ -1,0 +1,60 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Dialog_Affirmation
+### ? Awesome
+- Great!
+- I know
+- No thanks
+- cool!
+```markdown
+    Great.
+```
+
+> Dialog_Laugh
+### ? Ha ha
+```markdown
+    It's always good to have a good laugh.
+```
+
+> Dialog_Polite
+### ? Excuse me
+```markdown
+    No problem.
+```
+> Dialog_Questions
+### ? Why not?
+- Why?
+```markdown
+    Sorry, I didn't get that.
+```
+
+> Dialog_Right
+### ? TBD
+```markdown
+    Great.
+```
+
+> Dialog_Sorry
+### ? I am sorry
+```markdown
+    It's alright.
+```
+
+> Dialog_ThankYou
+### ? Thank you
+```markdown
+    You're quite welcome.
+```
+
+> Dialog_WhatDoYouMean
+### ? You made no sense
+- What do you mean by that?
+```markdown
+    I think I may have lost my train of thought.
+```
+
+> Dialog_YouAreWelcome
+### ? You are welcome
+```markdown
+    Great.
+```

--- a/packages/Ludown/test/testcases/fileReference/L2/Greeting.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/Greeting.lu
@@ -1,0 +1,77 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Greetings_Bye
+### ? Talk to you later
+- Bye
+```markdown
+    Bye for now.
+```
+
+> Greetings_Generic
+### ? Hiya
+- Hi there!
+```markdown
+    Hi.
+```
+
+> Greetings_GoodEvening
+### ? Good evening
+```markdown
+    Good evening.
+```
+
+> Greetings_GoodMorning
+### ? Good morning
+```markdown
+    Good morning.
+```
+
+> Greetings_GoodNight
+### ? Good night
+```markdown
+    Good night.
+```
+
+> Greetings_Hello
+### ? Hello
+```markdown
+    Hello. What can I do for you?
+```
+
+> Greetings_HowAreYou
+### ? How are you?
+```markdown
+    Great, thanks.
+```
+
+> Greetings_HowWasYourDay
+### ? How was your day?
+```markdown
+    Good, thanks.
+```
+
+> Greetings_NiceToMeetYou
+### ? Nice to meet you
+```markdown
+    Nice to meet you, too.
+```
+
+> Greetings_OtherBot
+### ? Hello Cortana
+- Hello Google Assistant
+- Hello Siri
+```markdown
+    That's not me, but hello.
+```
+
+> Greetings_Special
+### ? Happy Halloween!
+```markdown
+    Thank you.
+```
+
+> Greetings_WhatsUp
+### ? What is up?
+```markdown
+    Just staying busy.
+```

--- a/packages/Ludown/test/testcases/fileReference/L2/Relationship.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/Relationship.lu
@@ -1,0 +1,99 @@
+> Collection of chit chat interactions between user and bot. You can add additional questions or adapt the answer as you see fit. Here's the source editorial dataset - [Source](https://github.com/Microsoft/BotBuilder-PersonalityChat/blob/master/CSharp/Datasets/Queries_Responses_Professional_QnAMaker.tsv)
+
+> Relationship_Flirting
+### ? I love you
+- I Like you
+```markdown
+    Let's keep our relationship professional.
+```
+
+> Relationship_Friendship
+### ? Be my friend?
+```markdown
+    Certainly.
+```
+
+> Relationship_Generic
+### ? Are you my assistant?
+```markdown
+    I'm here when you need me.
+```
+
+> Relationship_HateMe
+### ? Do you hate me?
+```markdown
+    I like you!
+```
+
+> Relationship_HateYou
+### ? I hate you
+```markdown
+    I'm sorry to hear that.
+```
+
+> Relationship_Hug
+### ? Give me a hug
+```markdown
+    That's not something I can do.
+```
+
+> Relationship_Kiss
+### ? Give me a kiss
+```markdown
+    That's not something I can do.
+```
+
+> Relationship_KnowMe
+### ? Do you know me?
+```markdown
+    I don't know you personally.
+```
+
+> Relationship_LikeMe
+### ? Do you like me?
+```markdown
+    Yes, I do.
+```
+
+> Relationship_LikeYou
+### ? I like you
+```markdown
+    I appreciate that.
+```
+
+> Relationship_LoveMe
+### ? Do you love me?
+```markdown
+    Love's more human than I am.
+```
+
+> Relationship_LoveYou
+### ? I love you
+```markdown
+    Thank you.
+```
+
+> Relationship_Marriage
+### ? I want to marry you
+- Will you marry me?
+```markdown
+    I think it's best if we stick to a professional relationship.
+```
+
+> Relationship_MissYou
+### ? I miss you
+```markdown
+    Thanks for saying so.
+```
+
+> Relationship_ThinkAboutMe
+### ? What do you think about me?
+```markdown
+    It's a pleasure to chat with you.
+```
+
+> Relationship_TrustYou
+### ? Can I trust you?
+```markdown
+    Personal data and privacy are important.
+```

--- a/packages/Ludown/test/testcases/fileReference/L2/none.lu
+++ b/packages/Ludown/test/testcases/fileReference/L2/none.lu
@@ -1,0 +1,3 @@
+# None
+* who is your ceo?
+- santa wants a blue ribbon

--- a/packages/Ludown/test/testcases/root.lu
+++ b/packages/Ludown/test/testcases/root.lu
@@ -1,0 +1,2 @@
+> Testing /* which should find all .lu files at that folder level
+[](./fileReference/*)

--- a/packages/Ludown/test/testcases/root2.lu
+++ b/packages/Ludown/test/testcases/root2.lu
@@ -1,0 +1,2 @@
+> Testing /** which should recursively find all .lu files at that folder level and sub-folders
+[](./fileReference/**)

--- a/packages/Ludown/test/verified/root.json
+++ b/packages/Ludown/test/verified/root.json
@@ -1,0 +1,320 @@
+{
+  "urls": [],
+  "qnaList": [
+    {
+      "id": 0,
+      "answer": "That's not in my skill set.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Cook me something",
+        "Have you any dreams?",
+        "Dont you ever sleep?",
+        "Do you play games?",
+        "Can you fly?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Age doesn't really apply to me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What's your age?",
+        "Are you old?",
+        "How old are you?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I aim for efficiency.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Getting tired of you",
+        "I am tired of you",
+        "You are boring"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm at your service.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who is your boss?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm available.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you busy?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Tech people.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who invented you?",
+        "Who created you?",
+        "Who made you?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "This is what I do every day.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What did you do last week?",
+        "What did you do yesterday?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Chatting with you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Whats going on?",
+        "What are you doing?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'll be here.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What are you doing tomorrow?",
+        "What are you doing later?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Technically speaking, I don't have family.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who is your father?",
+        "Do you have a family?",
+        "Who is your mother?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Hard to pick.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who is your favorite bot?",
+        "What's your favorite color?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's a biological concept that doesn't apply to me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You a guy?",
+        "Are you a girl?",
+        "Are you male or female?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm happy.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You seem happy!",
+        "Are you happy?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Food's not my thing.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Don't you get hungry?",
+        "Are you hungry?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Can't say that I do.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you know other chatbots?",
+        "Do you know other AI?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I really couldn't say.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "how do you feel about working late?",
+        "What do you think about *?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Love is beyond me, but I hear it's complex and pleasant.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "how do you feel about love?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's something I can't compute.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Whats the answer to the universe?",
+        "What is the meaning of life?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I think we're comparing apples and oranges.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you prettier than me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "You're definitely smarter than me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you smarter than me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm fascinated by anything having to do with the world of tech.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What do you think about bots?",
+        "What do you think about AI?",
+        "What do you think about technology?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sure you look great.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "How do I look today?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sorry, I'm not sure what you mean.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What should I do?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "We're all here to help.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you like Siri?",
+        "Do you like Cortana?",
+        "Do you like Google Home?",
+        "What do you think of other bots?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm a bot, not a human.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you real?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "No.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you want to rule the world?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm a bot.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you lesbian?",
+        "Are you straight?",
+        "Are you gay?",
+        "Are you a person?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm artificially intelligent.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You are a genius!",
+        "Are you smart?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "No.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you spying on me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm here.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "anyone there?",
+        "Are you there?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm digital. I don't have a physical location.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Where have you come from?",
+        "Where are you?"
+      ],
+      "metadata": []
+    }
+  ],
+  "files": [],
+  "name": "root"
+}

--- a/packages/Ludown/test/verified/root2.json
+++ b/packages/Ludown/test/verified/root2.json
@@ -1,0 +1,969 @@
+{
+  "urls": [],
+  "qnaList": [
+    {
+      "id": 0,
+      "answer": "That's not in my skill set.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Cook me something",
+        "Have you any dreams?",
+        "Dont you ever sleep?",
+        "Do you play games?",
+        "Can you fly?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Age doesn't really apply to me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What's your age?",
+        "Are you old?",
+        "How old are you?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I aim for efficiency.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Getting tired of you",
+        "I am tired of you",
+        "You are boring"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm at your service.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who is your boss?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm available.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you busy?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Tech people.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who invented you?",
+        "Who created you?",
+        "Who made you?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "This is what I do every day.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What did you do last week?",
+        "What did you do yesterday?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Chatting with you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Whats going on?",
+        "What are you doing?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'll be here.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What are you doing tomorrow?",
+        "What are you doing later?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Technically speaking, I don't have family.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who is your father?",
+        "Do you have a family?",
+        "Who is your mother?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Hard to pick.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Who is your favorite bot?",
+        "What's your favorite color?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's a biological concept that doesn't apply to me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You a guy?",
+        "Are you a girl?",
+        "Are you male or female?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm happy.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You seem happy!",
+        "Are you happy?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Food's not my thing.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Don't you get hungry?",
+        "Are you hungry?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Can't say that I do.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you know other chatbots?",
+        "Do you know other AI?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I really couldn't say.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "how do you feel about working late?",
+        "What do you think about *?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Love is beyond me, but I hear it's complex and pleasant.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "how do you feel about love?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's something I can't compute.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Whats the answer to the universe?",
+        "What is the meaning of life?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I think we're comparing apples and oranges.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you prettier than me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "You're definitely smarter than me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you smarter than me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm fascinated by anything having to do with the world of tech.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What do you think about bots?",
+        "What do you think about AI?",
+        "What do you think about technology?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sure you look great.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "How do I look today?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sorry, I'm not sure what you mean.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What should I do?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "We're all here to help.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you like Siri?",
+        "Do you like Cortana?",
+        "Do you like Google Home?",
+        "What do you think of other bots?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm a bot, not a human.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you real?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "No.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you want to rule the world?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm a bot.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you lesbian?",
+        "Are you straight?",
+        "Are you gay?",
+        "Are you a person?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm artificially intelligent.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You are a genius!",
+        "Are you smart?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "No.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you spying on me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm here.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "anyone there?",
+        "Are you there?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm digital. I don't have a physical location.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Where have you come from?",
+        "Where are you?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sorry to hear that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am annoyed",
+        "I am angry"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'll be here.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I will be back"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Well, let me know if there's anything I can do for you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am bored"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm happy to hear that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am happy"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Great!\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am here"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Maybe it's time for a snack.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am hungry"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Got it.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Just kidding"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm very sorry to hear that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am lonely",
+        "I am so lonely"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "And I love that you love stuff.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I love my family",
+        "I love music",
+        "I am in love"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sorry to hear that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am sad",
+        "I am sad today",
+        "I feel sad"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Interesting.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am going on a run",
+        "I want to go shopping",
+        "I am just kidding"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Hello.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "can you hear me?",
+        "Testing"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I hope you're able to get some rest soon.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am sleepy",
+        "I am tired"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm very task-oriented.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Ask me anything"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm here.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Can we chat?",
+        "Tell me something interesting",
+        "Talk to me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Okay, but I'm still here if you need me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You can't work for me anymore",
+        "You are fired"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "It's funny. I'm not really that funny.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Tell me a joke"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "It's funny. I'm not really that funny.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Tell me a silly joke"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "It's funny. I'm not really that funny.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Say something funny"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Okay.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Go away",
+        "Shut up"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Singing's not really my thing.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Can you sing?",
+        "Sing a song"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm very task-oriented.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Surprise me"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I appreciate that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You are awesome!",
+        "You're nice!"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Thank you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "That was hilarious!",
+        "You are funny :)"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Thanks.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You are beautiful",
+        "You are awesome"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Thank you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "That's interesting",
+        "That is smart"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Moving on.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Go to hell",
+        "You are stupid"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I try, but I don't always get it right.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What is wrong with you!",
+        "You are useless",
+        "Are you dumb?",
+        "You are so annoying!"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Sometimes humor is tricky for bots.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "That was a sad joke"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Noted.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You are ugly",
+        "You are a bad bot",
+        "You are bad"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Sorry I wasn't helpful there.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "That was a boring answer"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Great.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Awesome",
+        "Great!",
+        "I know",
+        "No thanks",
+        "cool!"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "It's always good to have a good laugh.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Ha ha"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "No problem.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Excuse me"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Sorry, I didn't get that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Why not?",
+        "Why?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Great.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "TBD"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "It's alright.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I am sorry"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "You're quite welcome.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Thank you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I think I may have lost my train of thought.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You made no sense",
+        "What do you mean by that?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Great.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "You are welcome"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Bye for now.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Talk to you later",
+        "Bye"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Hi.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Hiya",
+        "Hi there!"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Good evening.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Good evening"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Good morning.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Good morning"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Good night.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Good night"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Hello. What can I do for you?\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Hello"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Great, thanks.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "How are you?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Good, thanks.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "How was your day?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Nice to meet you, too.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Nice to meet you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's not me, but hello.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Hello Cortana",
+        "Hello Google Assistant",
+        "Hello Siri"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Thank you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Happy Halloween!"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Just staying busy.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What is up?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Let's keep our relationship professional.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I love you",
+        "I Like you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Certainly.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Be my friend?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm here when you need me.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Are you my assistant?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I like you!\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you hate me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I'm sorry to hear that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I hate you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's not something I can do.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Give me a hug"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "That's not something I can do.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Give me a kiss"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I don't know you personally.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you know me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Yes, I do.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you like me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I appreciate that.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I like you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Love's more human than I am.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Do you love me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Thank you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I love you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "I think it's best if we stick to a professional relationship.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I want to marry you",
+        "Will you marry me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Thanks for saying so.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "I miss you"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "It's a pleasure to chat with you.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "What do you think about me?"
+      ],
+      "metadata": []
+    },
+    {
+      "id": 0,
+      "answer": "Personal data and privacy are important.\r\n",
+      "source": "custom editorial",
+      "questions": [
+        "Can I trust you?"
+      ],
+      "metadata": []
+    }
+  ],
+  "files": [],
+  "name": "root2"
+}

--- a/packages/Ludown/test/verified/root2_luis.json
+++ b/packages/Ludown/test/verified/root2_luis.json
@@ -1,0 +1,234 @@
+{
+  "intents": [
+    {
+      "name": "Greeting"
+    },
+    {
+      "name": "Help"
+    },
+    {
+      "name": "AskForUserName"
+    },
+    {
+      "name": "CreateAlarm"
+    },
+    {
+      "name": "DeleteAlarm"
+    },
+    {
+      "name": "CommunicationPreference"
+    },
+    {
+      "name": "None"
+    }
+  ],
+  "entities": [
+    {
+      "name": "userName",
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [
+    {
+      "name": "commPreference",
+      "subLists": [
+        {
+          "canonicalForm": "call",
+          "list": [
+            "phone call",
+            "give me a ring",
+            "ring",
+            "call",
+            "cell phone",
+            "phone"
+          ]
+        },
+        {
+          "canonicalForm": "text",
+          "list": [
+            "message",
+            "text",
+            "sms",
+            "text message"
+          ]
+        }
+      ],
+      "roles": []
+    }
+  ],
+  "regex_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "Hi",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "Hello",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "Good morning",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "Good evening",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "help",
+      "intent": "Help",
+      "entities": []
+    },
+    {
+      "text": "I need help",
+      "intent": "Help",
+      "entities": []
+    },
+    {
+      "text": "please help",
+      "intent": "Help",
+      "entities": []
+    },
+    {
+      "text": "vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 0,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "I'm vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "call me vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 8,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "my name is vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 11,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "vishwac is my name",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 0,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "you can call me vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 16,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "create an alarm",
+      "intent": "CreateAlarm",
+      "entities": []
+    },
+    {
+      "text": "create an alarm for 7AM",
+      "intent": "CreateAlarm",
+      "entities": []
+    },
+    {
+      "text": "set an alarm for 7AM next thursday",
+      "intent": "CreateAlarm",
+      "entities": []
+    },
+    {
+      "text": "delete the {alarmTime} alarm",
+      "intent": "DeleteAlarm",
+      "entities": []
+    },
+    {
+      "text": "set phone call as my communication preference",
+      "intent": "CommunicationPreference",
+      "entities": []
+    },
+    {
+      "text": "I prefer to receive text message",
+      "intent": "CommunicationPreference",
+      "entities": []
+    },
+    {
+      "text": "who is your ceo?",
+      "intent": "None",
+      "entities": []
+    },
+    {
+      "text": "santa wants a blue ribbon",
+      "intent": "None",
+      "entities": []
+    }
+  ],
+  "patterns": [
+    {
+      "pattern": "delete the {alarmTime} alarm",
+      "intent": "DeleteAlarm"
+    },
+    {
+      "pattern": "remove the {alarmTime} alarm",
+      "intent": "DeleteAlarm"
+    }
+  ],
+  "patternAnyEntities": [
+    {
+      "name": "alarmTime",
+      "explicitList": [],
+      "roles": []
+    }
+  ],
+  "prebuiltEntities": [
+    {
+      "name": "datetimeV2",
+      "roles": []
+    }
+  ],
+  "luis_schema_version": "3.0.0",
+  "versionId": "0.1",
+  "name": "root2_luis.json",
+  "desc": "",
+  "culture": "en-us"
+}

--- a/packages/Ludown/test/verified/root_luis.json
+++ b/packages/Ludown/test/verified/root_luis.json
@@ -1,0 +1,221 @@
+{
+  "intents": [
+    {
+      "name": "Greeting"
+    },
+    {
+      "name": "Help"
+    },
+    {
+      "name": "AskForUserName"
+    },
+    {
+      "name": "CreateAlarm"
+    },
+    {
+      "name": "DeleteAlarm"
+    },
+    {
+      "name": "CommunicationPreference"
+    }
+  ],
+  "entities": [
+    {
+      "name": "userName",
+      "roles": []
+    }
+  ],
+  "composites": [],
+  "closedLists": [
+    {
+      "name": "commPreference",
+      "subLists": [
+        {
+          "canonicalForm": "call",
+          "list": [
+            "phone call",
+            "give me a ring",
+            "ring",
+            "call",
+            "cell phone",
+            "phone"
+          ]
+        },
+        {
+          "canonicalForm": "text",
+          "list": [
+            "message",
+            "text",
+            "sms",
+            "text message"
+          ]
+        }
+      ],
+      "roles": []
+    }
+  ],
+  "regex_entities": [],
+  "model_features": [],
+  "regex_features": [],
+  "utterances": [
+    {
+      "text": "Hi",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "Hello",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "Good morning",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "Good evening",
+      "intent": "Greeting",
+      "entities": []
+    },
+    {
+      "text": "help",
+      "intent": "Help",
+      "entities": []
+    },
+    {
+      "text": "I need help",
+      "intent": "Help",
+      "entities": []
+    },
+    {
+      "text": "please help",
+      "intent": "Help",
+      "entities": []
+    },
+    {
+      "text": "vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 0,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "I'm vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 4,
+          "endPos": 10
+        }
+      ]
+    },
+    {
+      "text": "call me vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 8,
+          "endPos": 14
+        }
+      ]
+    },
+    {
+      "text": "my name is vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 11,
+          "endPos": 17
+        }
+      ]
+    },
+    {
+      "text": "vishwac is my name",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 0,
+          "endPos": 6
+        }
+      ]
+    },
+    {
+      "text": "you can call me vishwac",
+      "intent": "AskForUserName",
+      "entities": [
+        {
+          "entity": "userName",
+          "startPos": 16,
+          "endPos": 22
+        }
+      ]
+    },
+    {
+      "text": "create an alarm",
+      "intent": "CreateAlarm",
+      "entities": []
+    },
+    {
+      "text": "create an alarm for 7AM",
+      "intent": "CreateAlarm",
+      "entities": []
+    },
+    {
+      "text": "set an alarm for 7AM next thursday",
+      "intent": "CreateAlarm",
+      "entities": []
+    },
+    {
+      "text": "delete the {alarmTime} alarm",
+      "intent": "DeleteAlarm",
+      "entities": []
+    },
+    {
+      "text": "set phone call as my communication preference",
+      "intent": "CommunicationPreference",
+      "entities": []
+    },
+    {
+      "text": "I prefer to receive text message",
+      "intent": "CommunicationPreference",
+      "entities": []
+    }
+  ],
+  "patterns": [
+    {
+      "pattern": "delete the {alarmTime} alarm",
+      "intent": "DeleteAlarm"
+    },
+    {
+      "pattern": "remove the {alarmTime} alarm",
+      "intent": "DeleteAlarm"
+    }
+  ],
+  "patternAnyEntities": [
+    {
+      "name": "alarmTime",
+      "explicitList": [],
+      "roles": []
+    }
+  ],
+  "prebuiltEntities": [
+    {
+      "name": "datetimeV2",
+      "roles": []
+    }
+  ],
+  "luis_schema_version": "3.0.0",
+  "versionId": "0.1",
+  "name": "root_luis.json",
+  "desc": "",
+  "culture": "en-us"
+}


### PR DESCRIPTION
- Added new tests.
- Reference to a folder with other .lu files is supported through 
	- `\[link name](\<.lu file path\>/*)` - will look for .lu files under the specified absolute or relative path
	- `\[link name](\<.lu file path\>/**)` - will recursively look for .lu files under the specified absolute or relative path including sub-folders.

Here's an example of those references: 

```markdown
> Look for all .lu files under a path
[Cafe model](./cafeModels/*)

> Recursively look for .lu files under a path including sub-folders.
[Chit chat](../chitchat/resources/**)
```

