### PR TITLE
[Build] Split `coverage` and `coveralls` scripts

### DIFF
--- a/build.ci.sh
+++ b/build.ci.sh
@@ -18,7 +18,7 @@ main() {
             npm run build
             npm run eslint
             npm run tslint
-            npm run coverage
+            npm run coveralls
         )
 
     fi

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "scripts": {
         "build": "lerna bootstrap && lerna run build",
         "test": "lerna run test --parallel",
-        "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+        "coverage": "nyc npm test",
+        "coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
         "eslint": "eslint --format \"node_modules/eslint-friendly-formatter\" \"./packages/**/*.js\" \"./packages/@(Dispatch|LUIS|LUISGen|QnAMaker)/bin/*\"",
         "tslint": "tslint ./packages/*/src/**/*.ts -t verbose"
     },


### PR DESCRIPTION
## Proposed Changes
 - To make easier running code coverage locally we extracted the `coverage` script.
 - To keep Coveralls integration we created `coveralls` script reusing `coverage`.
 - Updated `build.ci.sh` to run `coveralls`


## Testing
To run code coverage locally:
```
npm install
npm run build
npm run coverage
```