### PR TITLE
Fixed TSLint warnings in msbot-connect-*.ts files

### DIFF
--- a/packages/MSBot/src/msbot-connect-appinsights.ts
+++ b/packages/MSBot/src/msbot-connect-appinsights.ts
@@ -42,7 +42,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectAppInsightsArgs>{};
+const args: IConnectAppInsightsArgs = <IConnectAppInsightsArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-blob.ts
+++ b/packages/MSBot/src/msbot-connect-blob.ts
@@ -20,8 +20,6 @@ interface IConnectBlobArgs extends IBlobStorageService {
     secret: string;
     stdin: boolean;
     input?: string;
-    // tslint:disable-next-line:no-any
-    [key: string]: any;
 }
 
 program
@@ -42,7 +40,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectBlobArgs>{};
+const args: IConnectBlobArgs = <IConnectBlobArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-bot.ts
+++ b/packages/MSBot/src/msbot-connect-bot.ts
@@ -24,7 +24,6 @@ interface IConnectAzureArgs extends IBotService {
     appId?: string;
     appPassword?: string;
     endpoint?: string;
-    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -46,7 +45,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectAzureArgs>{};
+const args: IConnectAzureArgs = <IConnectAzureArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-connect-cosmosdb.ts
@@ -41,7 +41,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectCosmosDbArgs>{};
+const args: IConnectCosmosDbArgs = <IConnectCosmosDbArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -33,7 +33,7 @@ program
     .option('r, --region <region>', 'region to use (defaults to westus)')
     .option('--subscriptionKey <subscriptionKey>', '(OPTIONAL) subscription key used for querying the dispatch model')
     .option('--serviceIds <serviceIds>',
-        '(OPTIONAL) comma delimited list of service ids in this bot (qna or luis) to build a dispatch model over.')
+            '(OPTIONAL) comma delimited list of service ids in this bot (qna or luis) to build a dispatch model over.')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
@@ -42,7 +42,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectDispatchArgs>{};
+const args: IConnectDispatchArgs = <IConnectDispatchArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {
@@ -95,7 +95,7 @@ async function processConnectDispatch(config: BotConfiguration): Promise<BotConf
         throw new Error('bad --subscriptionKey');
     }
 
-    const dispatchService = <ITempDispatchService>{};
+    const dispatchService: ITempDispatchService = <ITempDispatchService>{};
     Object.assign(dispatchService, args);
     const newService: IDispatchService = new DispatchService(dispatchService);
 

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -21,7 +21,6 @@ interface IConnectEndpointArgs extends IEndpointService {
     secret: string;
     stdin: boolean;
     input?: string;
-    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -39,7 +38,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectEndpointArgs>{};
+const args: IConnectEndpointArgs = <IConnectEndpointArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
-import { BotConfiguration, FileService, IFileService } from 'botframework-config';
+import { BotConfiguration, FileService, IFileService, ConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as path from 'path';
@@ -34,7 +34,7 @@ program
     });
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectFileArgs>{};
+const args: IConnectFileArgs = <IConnectFileArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {
@@ -58,15 +58,15 @@ if (process.argv.length < 3) {
 }
 
 async function processConnectFile(config: BotConfiguration): Promise<BotConfiguration> {
-    if (!args.path && !args.file)
-        throw new Error('missing --file');
+    if (!args.path && !args.file) {
+        throw new Error('missing --file'); }
 
     // add the service
-    const newService = new FileService({
+    const newService: FileService = new FileService({
         name: path.basename(args.file || args.path),
         path: (args.file || args.path).replace('\\', '/')
     } as IFileService);
-    const id = config.connectService(newService);
+    const id: string = config.connectService(newService);
     await config.save(args.secret);
     process.stdout.write(JSON.stringify(config.findService(id), null, 2));
 

--- a/packages/MSBot/src/msbot-connect-generic.ts
+++ b/packages/MSBot/src/msbot-connect-generic.ts
@@ -38,7 +38,7 @@ program
     });
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectGenericArgs>{};
+const args: IConnectGenericArgs = <IConnectGenericArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -20,7 +20,6 @@ interface IConnectLuisArgs extends ILuisService {
     secret: string;
     stdin: boolean;
     input?: string;
-    [key: string]: string | boolean | undefined;
 }
 
 program
@@ -31,7 +30,7 @@ program
     .option('--version <version>', 'version for the LUIS App, (example: v0.1)')
     .option('-r, --region <region>', 'region for the LUIS App, (default:westus)')
     .option('--authoringKey <authoringkey>',
-        'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
+            'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
     .option('--subscriptionKey <subscriptionKey>', '(OPTIONAL) subscription key used for querying a LUIS model\n')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
@@ -41,7 +40,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectLuisArgs>{};
+const args: IConnectLuisArgs = <IConnectLuisArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -44,7 +44,7 @@ program
 program.parse(process.argv);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IConnectQnaArgs>{};
+const args: IConnectQnaArgs = <IConnectQnaArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following TSlint warnings:
- typedef
- align
- curly

## Testing
Travis will no longer report these warnings