### PR TITLE
Fix TSLint issues in MSBot files

### DIFF
--- a/packages/MSBot/src/msbot-disconnect.ts
+++ b/packages/MSBot/src/msbot-disconnect.ts
@@ -30,7 +30,7 @@ program
     });
 
 const command: program.Command = program.parse(process.argv);
-const args = <IDisconnectServiceArgs>{};
+const args: IDisconnectServiceArgs = <IDisconnectServiceArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/msbot-export.ts
+++ b/packages/MSBot/src/msbot-export.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
-import { BotConfiguration } from 'botframework-config';
+import { BotConfiguration, BotRecipe, IConnectedService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as process from 'process';
@@ -29,24 +29,24 @@ program
     .option('--verbose', 'show verbose export information')
     .option('-q, --quiet', 'disable output')
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
-    .action((cmd, actions) => undefined);
+    .action((cmd: program.Command, actions: program.Command) => undefined);
 program.parse(process.argv);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IExportArgs>{};
+const args: IExportArgs = <IExportArgs>{};
 Object.assign(args, command);
 
 if (!args.bot) {
     BotConfiguration.loadBotFromFolder(process.cwd(), args.secret)
         .then(processConfiguration)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
 } else {
     BotConfiguration.load(args.bot, args.secret)
         .then(processConfiguration)
-        .catch((reason) => {
+        .catch((reason: Error) => {
             console.error(chalk.default.redBright(reason.toString().split('\n')[0]));
             showErrorHelp();
         });
@@ -58,13 +58,13 @@ async function processConfiguration(config: BotConfiguration): Promise<void> {
     }
     try {
 
-        let recipe = await config.export(args.folder, {
-            progress: (service, command, index, total) => {
+        const recipe: BotRecipe = await config.export(args.folder, {
+            progress: (service: IConnectedService, newCommand: string, index: number, total: number): void => {
                 if (!args.quiet) {
-                    let output = `exporting ${chalk.default.bold(service.name)} [${service.type}] (${index}/${total})`;
+                    const output: string = `exporting ${chalk.default.bold(service.name)} [${service.type}] (${index}/${total})`;
                     if (args.verbose) {
                         console.warn(chalk.default.bold(output));
-                        console.log(chalk.default.italic(command + '\n'));
+                        console.log(chalk.default.italic(`${newCommand}\n`));
                     } else {
                         console.warn(output);
                     }
@@ -72,21 +72,21 @@ async function processConfiguration(config: BotConfiguration): Promise<void> {
             }
         });
     } catch (error) {
-        let lines = error.message.split('\n');
-        let message = '';
-        for (let line of lines) {
+        const lines: string[] = error.message.split('\n');
+        for (const line of lines) {
             // trim to copywrite symbol, help from inner process command line args is inappropriate
-            if (line.indexOf('©') > 0)
-                process.exit(1);
+            if (line.indexOf('©') > 0) {
+                process.exit(1); }
             console.error(chalk.default.redBright(line));
         }
     }
 
 }
 
-function showErrorHelp() {
-    program.outputHelp((str) => {
+function showErrorHelp(): void {
+    program.outputHelp((str: string) => {
         console.error(str);
+
         return '';
     });
     process.exit(1);

--- a/packages/MSBot/src/msbot-get.ts
+++ b/packages/MSBot/src/msbot-get.ts
@@ -28,7 +28,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IListArgs>{};
+const args: IListArgs = <IListArgs>{};
 Object.assign(args, command);
 
 if (!args.bot) {

--- a/packages/MSBot/src/msbot-init.ts
+++ b/packages/MSBot/src/msbot-init.ts
@@ -38,7 +38,7 @@ program
     });
 
 const command: program.Command = program.parse(process.argv);
-const args = <IInitArgs>{};
+const args: IInitArgs = <IInitArgs>{};
 Object.assign(args, command);
 
 if (!args.quiet) {
@@ -53,18 +53,19 @@ if (!args.quiet) {
     }
 
     while (!args.endpoint || args.endpoint.length === 0) {
-        args.endpoint = readline.question(`What localhost endpoint does your bot use for debugging [Example: http://localhost:3978/api/messages]? `, {
-            defaultInput: ' '
-        });
+        // tslint:disable-next-line:max-line-length
+        args.endpoint = readline.question(`What localhost endpoint does your bot use for debugging? ` +
+                                          `[Example: http://localhost:3978/api/messages] `,
+                                          { defaultInput: ' ' });
     }
 
     if (validurl.isHttpUri(args.endpoint) || validurl.isHttpsUri(args.endpoint)) {
 
         if (!args.appId || args.appId.length === 0) {
-            const answer = readline.question(`Do you have an appId for endpoint? [no] `, {
+            const answer: string = readline.question(`Do you have an appId for endpoint? [no] `, {
                 defaultInput: 'no'
             });
-            if (answer == 'y' || answer === 'yes') {
+            if (answer === 'y' || answer === 'yes') {
                 args.appId = readline.question(`What is your appId for ${args.endpoint}? [none] `, {
                     defaultInput: ''
                 });

--- a/packages/MSBot/src/msbot-list.ts
+++ b/packages/MSBot/src/msbot-list.ts
@@ -26,7 +26,7 @@ program
     .action((cmd: program.Command, actions: program.Command) => undefined);
 
 const command: program.Command = program.parse(process.argv);
-const args = <IListArgs>{};
+const args: IListArgs = <IListArgs>{};
 Object.assign(args, command);
 
 if (!args.bot) {

--- a/packages/MSBot/src/msbot-secret.ts
+++ b/packages/MSBot/src/msbot-secret.ts
@@ -31,7 +31,7 @@ program
     });
 
 const command: program.Command = program.parse(process.argv);
-const args = <ISecretArgs>{};
+const args: ISecretArgs = <ISecretArgs>{};
 Object.assign(args, command);
 
 if (process.argv.length < 3) {

--- a/packages/MSBot/src/processUtils.ts
+++ b/packages/MSBot/src/processUtils.ts
@@ -1,29 +1,36 @@
-import * as child_process from "child_process";
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+import * as child_process from 'child_process';
 
 // child_process.spawn isn't promise and is complicated in how to captures stream of stdout/sterr
 export function spawnAsync(command: string, stdout?: (data: string) => void, stderr?: (data: string) => void): Promise<string> {
-    return new Promise<any>((resolve, reject) => {
-        let parts = command.split(' ');
-        let p = child_process.spawn(parts[0], parts.slice(1), { shell: true, stdio: ['inherit', 'pipe', 'pipe'] });
-        let out = '';
-        p.stderr.on('data', (data) => {
+    return new Promise<string>((resolve: (value?: string) => void, reject: (value?: string) => void): void => {
+        const parts: string[] = command.split(' ');
+        const p: child_process.ChildProcess = child_process.spawn(parts[0], parts.slice(1), {
+            shell: true, stdio: ['inherit', 'pipe', 'pipe']
+        });
+        let out: string = '';
+        p.stderr.on('data', (data: Buffer) => {
             if (stderr) {
                 stderr(data.toString('utf8'));
             }
-        })
+        });
 
-        p.stdout.on('data', (data) => {
+        p.stdout.on('data', (data: Buffer) => {
             out += data;
             if (stdout) {
                 stdout(data.toString('utf8'));
             }
-        })
+        });
 
-        p.on('close', (code) => {
-            if (code > 0)
-                reject('' + code);
-            else
+        p.on('close', (code: number) => {
+            if (code > 0) {
+                reject(` ${code}`);
+            } else {
                 resolve(out);
+            }
         });
     });
 }

--- a/packages/MSBot/src/utils.ts
+++ b/packages/MSBot/src/utils.ts
@@ -5,4 +5,3 @@
 export function uuidValidate(value: string): boolean {
     return /^[0-9a-f]{8}-?[0-9a-f]{4}-?[1-5][0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$/.test(value);
 }
-


### PR DESCRIPTION
Related to #313

## Proposed Changes
Fix the following rules
- curly
- eofline
- max-line-length
- newline-before-return
- no-shadowed-variable
- prefer-const
- prefer-template
- triple-equals
- typedef
- Add MIT license header to `processUtils.ts`.
- Remove unused variable `message` at line 76 of file `msbot-export.ts`.
- Split string in line 56 of file `msbot-init.ts` into two to avoid `max-line-length` warning.
- Rename variable `command` inside of `recipe` to `newCommand` to avoid _naming shadowing_. 

## Testing
Travis will no longer report these warnings