### PR TITLE
include operation.json in package

### DIFF
--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -15,7 +15,7 @@
     "examples": "examples"
   },
   "files": [
-    "bin/**/*.js",
+    "bin/**/*.js*",
     "lib/**/*.js",
     "typings/**/*.d.ts"
   ],


### PR DESCRIPTION
packages.config added explicit list of files to include and pattern didn't include .json file which drives entire command line help system.

Fix: I include the critical file. :)