### PR TITLE
Disable TSLint rule for no-object-literal-type-assertion in msbot-connect*.ts files

### DIFF
--- a/packages/MSBot/src/msbot-connect-appinsights.ts
+++ b/packages/MSBot/src/msbot-connect-appinsights.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { AppInsightsService, BotConfiguration, IAppInsightsService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-blob.ts
+++ b/packages/MSBot/src/msbot-connect-blob.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BlobStorageService, BotConfiguration, IBlobStorageService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-bot.ts
+++ b/packages/MSBot/src/msbot-connect-bot.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, BotService, EndpointService, IBotService, IConnectedService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-connect-cosmosdb.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, CosmosDbService, ICosmosDBService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, DispatchService, IConnectedService, IDispatchService, ILuisService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, EndpointService, IEndpointService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-file.ts
+++ b/packages/MSBot/src/msbot-connect-file.ts
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
-import { BotConfiguration, FileService, IFileService, ConnectedService } from 'botframework-config';
+// tslint:disable:no-object-literal-type-assertion
+import { BotConfiguration, FileService, IFileService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
 import * as path from 'path';

--- a/packages/MSBot/src/msbot-connect-generic.ts
+++ b/packages/MSBot/src/msbot-connect-generic.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, GenericService, IGenericService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, ILuisService, LuisService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 // tslint:disable:no-console
+// tslint:disable:no-object-literal-type-assertion
 import { BotConfiguration, IQnAService, QnaMakerService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';


### PR DESCRIPTION
## Proposed Changes
  - Disable TSLint rule for no-object-literal-type-assertion

## Testing
Travis should no longer report this warning