### PR TITLE
Add --prefix arg to enable prefix in QnA

### DIFF
--- a/packages/QnAMaker/bin/qnamaker.js
+++ b/packages/QnAMaker/bin/qnamaker.js
@@ -33,6 +33,7 @@ const Operations = require('../lib/api/operations');
 const Delay = require('await-delay');
 const { ServiceBase } = require('../lib/api/serviceBase');
 const latestVersion = require('latest-version');
+const intercept = require("intercept-stdout");
 
 function stdoutAsync(output) { return new Promise((done) => process.stdout.write(output, "utf-8", () => done())); }
 
@@ -62,6 +63,12 @@ async function runProgram() {
     }
 
     args = minimist(argvFragment);
+
+    if (args.prefix) {
+        const unhook_intercept = intercept(function(txt) {
+            return `[${pkg.name}]\n${txt}`;
+        });
+    }
 
     if (args['!'] ||
         args.help ||

--- a/packages/QnAMaker/bin/qnamaker.js
+++ b/packages/QnAMaker/bin/qnamaker.js
@@ -65,7 +65,7 @@ async function runProgram() {
     args = minimist(argvFragment);
 
     if (args.prefix) {
-        const unhook_intercept = intercept(function(txt) {
+        intercept(function(txt) {
             return `[${pkg.name}]\n${txt}`;
         });
     }

--- a/packages/QnAMaker/package-lock.json
+++ b/packages/QnAMaker/package-lock.json
@@ -595,6 +595,14 @@
         "p-is-promise": "^1.1.0"
       }
     },
+    "intercept-stdout": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/intercept-stdout/-/intercept-stdout-0.1.2.tgz",
+      "integrity": "sha1-Emq/H65sUJpCipjGGmMVWQQq6f0=",
+      "requires": {
+        "lodash.toarray": "^3.0.0"
+      }
+    },
     "is-accessor-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -745,6 +753,51 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.toarray": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-3.0.2.tgz",
+      "integrity": "sha1-KyBPD6T1HChcbwDIHRzqWiMEEXk=",
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
     },
     "latest-version": {
       "version": "4.0.0",

--- a/packages/QnAMaker/package.json
+++ b/packages/QnAMaker/package.json
@@ -36,6 +36,7 @@
     "fs-extra": "^5.0.0",
     "get-stdin": "^6.0.0",
     "hoek": "^5.0.3",
+    "intercept-stdout": "^0.1.2",
     "latest-version": "^4.0.0",
     "md5": "^2.2.1",
     "minimist": "^1.2.0",

--- a/packages/QnAMaker/test/qnamaker.cli.test.suite.js
+++ b/packages/QnAMaker/test/qnamaker.cli.test.suite.js
@@ -4,6 +4,7 @@ const qnamaker = require.resolve('../bin/qnamaker');
 const createKbNoName = require.resolve('../examples/CreateKbNoNameDTO.json');
 const createKb = require.resolve('../examples/CreateKbDTO.json');
 const updateKbOperation = require.resolve('../examples/UpdateKbOperationDTO.json');
+const pkg = require('../package.json');
 
 const subscriptionKey = process.env.QNA_SUBSCRIPTION_KEY;
 
@@ -28,6 +29,27 @@ describe('The QnA Maker cli bin', () => {
         exec(`node ${qnamaker} query`, (error, stdout, stderr) => {
             assert.equal(stdout, '');
             assert(stderr.includes('The --question argument is missing and required'));
+            done();
+        });
+    });
+
+    it('should not prefix [qna] to stdout when --prefix is not passed as an argument', done => {
+        exec(`node ${qnamaker} -h`, (error, stdout) => {
+            assert.notEqual(stdout.startsWith(`[${pkg.name}]`), `It should not show the tag '[${pkg.name}]' when not using the argument --prefix`);
+            done();
+        });
+    });
+
+    it('should prefix [qna] to stdout when --prefix is passed as an argument', done => {
+        exec(`node ${qnamaker} -h --prefix`, (error, stdout) => {
+            assert(stdout.startsWith(`[${pkg.name}]`), `It should show the tag '[${pkg.name}]' when using the argument --prefix`);
+            done();
+        });
+    });
+
+    it('should prefix [qna] to stderr when --prefix is passed as an argument', done => {
+        exec(`node ${qnamaker} foo --prefix`, (error, stdout, stderr) => {
+            assert(stderr.startsWith(`[${pkg.name}]`), `It should show the tag '[${pkg.name}]' when using the argument --prefix`);
             done();
         });
     });


### PR DESCRIPTION
## Proposed Changes
Add `--prefix` arg to enable prefix in messages in `QnAMaker`.

## Testing
Three new tests were added to validate the correct use of the prefix.