### PR TITLE
Add test runner and tests for LUIS 'add' & 'get' verb

### DIFF
--- a/packages/LUIS/test/luis.cli.specs.suite.js
+++ b/packages/LUIS/test/luis.cli.specs.suite.js
@@ -1,0 +1,6 @@
+const path = require('path');
+const runTests = require('./testRunner.js').runTests;
+
+describe('The LUIS cli tool', () => {
+    runTests(`${__dirname}/${path.parse(__filename).name}`);
+});

--- a/packages/LUIS/test/luis.cli.specs.suite.js
+++ b/packages/LUIS/test/luis.cli.specs.suite.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const runTests = require('./testRunner.js').runTests;
+const { runTests } = require('./testRunner.js');
 
 describe('The LUIS cli tool', () => {
     runTests(`${__dirname}/${path.parse(__filename).name}`);

--- a/packages/LUIS/test/luis.cli.specs.suite/with-add-verb.spec.json
+++ b/packages/LUIS/test/luis.cli.specs.suite/with-add-verb.spec.json
@@ -1,0 +1,213 @@
+{
+	"describe": "with 'add' verb",
+	"tests": [{
+			"title": "and 'application'",
+			"args": "add app --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "Access denied due to invalid subscription key.",
+			"resource": ["ApplicationCreateObject.json"]
+		},
+		{
+			"title": "and 'closedlist'",
+			"args": "add closedlist --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ClosedListModelCreateObject.json"]
+		},
+		{
+			"title": "and 'closedlistentityrole'",
+			"args": "add closedlistentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ClosedListModelCreateObject.json"]
+		},
+		{
+			"title": "and 'compositeentity'",
+			"args": "add compositeentity --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["CompositeEntityModel.json"]
+		},
+		{
+			"title": "and 'compositeentitychild'",
+			"args": "add compositeentitychild --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["CompositeEntityModel.json"]
+		},
+		{
+			"title": "and 'compositeentityrole'",
+			"args": "add compositeentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["CompositeEntityModel.json"]
+		},
+		{
+			"title": "and 'customprebuiltdomain'",
+			"args": "add customprebuiltdomain --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PrebuiltDomainCreateObject.json"]
+		},
+		{
+			"title": "and 'customprebuiltentity'",
+			"args": "add customprebuiltentity --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["CompositeEntityModel.json"]
+		},
+		{
+			"title": "and 'customprebuiltentityrole'",
+			"args": "add customprebuiltentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["CompositeEntityModel.json"]
+		},
+		{
+			"title": "and 'customprebuiltintent'",
+			"args": "add customprebuiltintent --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PrebuiltDomainModelCreateObject.json"]
+		},
+		{
+			"title": "and 'entity'",
+			"args": "add entity --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ModelCreateObject.json"]
+		},
+		{
+			"title": "and 'entityrole'",
+			"args": "add entityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["EntityRole.json"]
+		},
+		{
+			"title": "and 'examples'",
+			"args": "add examples --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ExampleLabelObject.json"]
+		},
+		{
+			"title": "and 'example'",
+			"args": "add example --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ExampleLabelObject.json"]
+		},
+		{
+			"title": "and 'explicitlistitem'",
+			"args": "add explicitlistitem --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ExplicitListItemCreateObject.json"]
+		},
+		{
+			"title": "and 'hierarchicalentity'",
+			"args": "add hierarchicalentity --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["HierarchicalEntityModel.json"]
+		},
+		{
+			"title": "and 'hierarchicalentitychild'",
+			"args": "add hierarchicalentitychild --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["HierarchicalEntityModel.json"]
+		},
+		{
+			"title": "and 'hierarchicalentityrole'",
+			"args": "add hierarchicalentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["HierarchicalEntityModel.json"]
+		},
+		{
+			"title": "and 'intent'",
+			"args": "add intent --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["ModelCreateObject.json"]
+		},
+		{
+			"title": "and 'pattern'",
+			"args": "add pattern --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PatternAnyModelCreateObject.json"]
+		},
+		{
+			"title": "and 'patternentityrole'",
+			"args": "add patternentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PatternAnyModelCreateObject.json"]
+		},
+		{
+			"title": "and 'patterns'",
+			"args": "add patterns --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PatternAnyModelCreateObject.json"]
+		},
+		{
+			"title": "and 'permissions'",
+			"args": "add permissions --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["UserCollaborator.json"]
+		},
+		{
+			"title": "and 'phraselist'",
+			"args": "add phraselist --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PhraselistCreateObject.json"]
+		},
+		{
+			"title": "and 'prebuilt'",
+			"args": "add prebuilt --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PrebuiltExtractorNames.json"]
+		},
+		{
+			"title": "and 'prebuiltentityrole'",
+			"args": "add prebuiltentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["PrebuiltExtractorNames.json"]
+		},
+		{
+			"title": "and 'regexentity'",
+			"args": "add regexentity --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["RegexModelCreateObject.json"]
+		},
+		{
+			"title": "and 'regexentityrole'",
+			"args": "add regexentityrole --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["RegexModelCreateObject.json"]
+		},
+		{
+			"title": "and 'sublist'",
+			"args": "add sublist --in %s --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined.",
+			"resource": ["WordListObject.json"]
+		},
+		{
+			"title": "and invalid resource",
+			"args": "add invalidResource --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "'invalidResource' is not a valid resource"
+		}
+	]
+}

--- a/packages/LUIS/test/luis.cli.specs.suite/with-get-verb.spec.json
+++ b/packages/LUIS/test/luis.cli.specs.suite/with-get-verb.spec.json
@@ -1,0 +1,148 @@
+{
+	"describe": "with 'get' verb",
+	"tests": [{
+			"title": "with target app",
+			"args": "get app --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target closedlist",
+			"args": "get closedlist --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target closedlistentityrole",
+			"args": "get closedlistentityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target compositeentity",
+			"args": "get compositeentity --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target compositeentitychild",
+			"args": "get compositeentitychild --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "'compositeentitychild' is not a valid resource"
+		},
+		{
+			"title": "with target compositeentityrole",
+			"args": "get compositeentityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target entity",
+			"args": "get entity --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target entityrole",
+			"args": "get entityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target explicitlistitem",
+			"args": "get explicitlistitem --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target hierarchicalentity",
+			"args": "get hierarchicalentity --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target hierarchicalentitychild",
+			"args": "get hierarchicalentitychild --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target hierarchicalentityrole",
+			"args": "get hierarchicalentityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target intent",
+			"args": "get intent --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target pattern",
+			"args": "get pattern --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target patternentityrole",
+			"args": "get patternentityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target phraselist",
+			"args": "get phraselist --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target prebuilt",
+			"args": "get prebuilt --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target prebuiltentityrole",
+			"args": "get prebuiltentityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target regexentity",
+			"args": "get regexentity --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target regexentityrole",
+			"args": "get regexentityrole --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target settings",
+			"args": "get settings --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target status",
+			"args": "get status --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "with target version",
+			"args": "get version --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "appId cannot be null or undefined."
+		},
+		{
+			"title": "and invalid resource",
+			"args": "add invalidResource --authoringKey dummyKey --region westus",
+			"stdout": "",
+			"stderr": "'invalidResource' is not a valid resource"
+		}
+	]
+}

--- a/packages/LUIS/test/testRunner.js
+++ b/packages/LUIS/test/testRunner.js
@@ -1,0 +1,62 @@
+Object.defineProperty(exports, "__esModule", { value: true });
+const assert = require('assert');
+const util = require( "util" );
+const {exec} = require('child_process');
+const luis = require.resolve('../bin/luis');
+const fs = require('fs');
+const specsExtension = '.spec.json';
+
+function runTests(specsDirectory) {
+    if (fs.existsSync(specsDirectory)) {
+        fs.readdirSync(specsDirectory).filter(specsFile => specsFile.endsWith(specsExtension)).forEach(file => {
+            const testGroup = JSON.parse(fs.readFileSync(`${specsDirectory}/${file}`, 'utf8'));
+
+            describe(testGroup.describe, () => {
+                executeTestGroup(testGroup.tests);
+            });
+        })
+    }
+    else {
+        throw Error(`Specs directory '${specsDirectory} does not exists.`);
+    }
+}
+
+function executeTestGroup (tests) {
+    tests.forEach((test) => {
+        let command = `node ${luis}  ${test.args}`;
+
+        if(test.resource) {
+            command = getResources(test, command); }
+
+        executeTest(test, command);
+    });
+}
+
+function getResources (test, command) {
+    test.resource.forEach(resource => {
+        const resourcePath = `../examples/${resource}`;
+        if (fs.existsSync(resourcePath, 'resource')) {
+            const AppObject = require.resolve(resourcePath);
+            command = util.format(command, AppObject)
+        }
+        else {
+            throw Error(`Resource file '${resourcePath} does not exists.`);
+        }    
+    });
+
+    return command;
+}
+
+function executeTest (test, command) {
+    it(test.title, done => {                
+        exec(command, (error, stdout, stderr) => {
+            if(!test.stdout) assert(!stdout);
+            if (!test.stderr) assert(!stderr);
+            assert(stdout.includes(test.stdout));
+            assert(stderr.includes(test.stderr));
+            done();
+        });
+    }); 
+}
+
+exports.runTests = runTests;

--- a/packages/LUIS/test/testRunner.js
+++ b/packages/LUIS/test/testRunner.js
@@ -1,4 +1,3 @@
-Object.defineProperty(exports, "__esModule", { value: true });
 const assert = require('assert');
 const util = require( "util" );
 const {exec} = require('child_process');


### PR DESCRIPTION
Improve code coverage in LUIS CLI

## Proposed Changes
- Added new test runner to run tests cases from spec json files
- Added new mocha test suite to use test runner and feed with spec files
- Added LUIS CLI 'add' verb argument test cases
- [update] Added LUIS CLI 'get' verb argument test cases

## Testing
Coveralls code coverage for LUIS CLI should raise