### PR TITLE
Closed ms clone service issue

### DIFF
--- a/packages/MSBot/src/msbot-clone-services.ts
+++ b/packages/MSBot/src/msbot-clone-services.ts
@@ -252,7 +252,7 @@ async function processConfiguration(): Promise<void> {
 
         command = `az account show `;
         if (args.subscriptionId) {
-            command += `--subscription ${args.subscriptionId}`;
+            command += ` --subscription ${args.subscriptionId}`;
         }
 
         let azAccount = await runCommand(command, `Fetching subscription account`);


### PR DESCRIPTION
There is a bug with these lines:

https://github.com/Microsoft/botbuilder-tools/blob/08ff1fb1e2ef7b060549b57ee8189549556d04ce/packages/MSBot/src/msbot-clone-services.ts#L255

```
        command = `az account show `;
        if (args.subscriptionId) {
            command += `--subscription ${args.subscriptionId}`;
        }
```

The error is like this:


![image](https://user-images.githubusercontent.com/3538629/46512571-4d6e1400-c887-11e8-868d-44792232fb12.png)


it should be 

```
        command = `az account show `;
        if (args.subscriptionId) {
            command += ` --subscription ${args.subscriptionId}`;
        }
```.
