### PR TITLE
Update LUISGen.csproj

### DIFF
--- a/packages/LUISGen/src/LUISGen.csproj
+++ b/packages/LUISGen/src/LUISGen.csproj
@@ -28,7 +28,7 @@
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
         <SignAssembly>true</SignAssembly>
         <DelaySign>true</DelaySign>
-        <AssemblyOriginatorKeyFile>..\..\..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+        <AssemblyOriginatorKeyFile>..\..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     </PropertyGroup>
 


### PR DESCRIPTION
Fixes Broken build. 

The key file path being specified has an extra "..\" in it, which causes signing to fail. Manually running a build against this branch passes. 

Fixes #653