### PR TITLE
Add .net core to pre-reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Bot Builder tools is a collection of cross-platform command line tools designed 
 | [![npm version](https://badge.fury.io/js/luisgen.svg)](https://badge.fury.io/js/luisgen)| [LUISGen](packages/LUISGen) | Auto generate backing C#/Typescript classes for your LUIS intents and entities.|
 
 ## Install CLI tools:
-Pre-requisite: [Node.js](https://nodejs.org/) version 8.5 or higher
+Pre-requisite: 
+- [Node.js](https://nodejs.org/) version 8.5 or higher
+- [.NET Core SDK](https://www.microsoft.com/net/download) version 2.1.403 or higher
 
 ```
 npm install -g chatdown msbot ludown luis-apis qnamaker botdispatch luisgen


### PR DESCRIPTION
## Proposed Changes
LUISGen and LUIS require .net core.  so added this to the pre-reqs section of the readme
