### PR TITLE
Fix for ludown translate test

### DIFF
--- a/packages/Ludown/test/verified/zh-Hans/reduced.lu
+++ b/packages/Ludown/test/verified/zh-Hans/reduced.lu
@@ -3,7 +3,7 @@
 - 改变{Subject=午餐日期}从{OriginalStartTime=11}-{OriginalEndTime=12}自{StartTime=12}-{EndTime=1 30}
 - 移动我{OriginalStartTime=10过去10} {Subject=医生预约}自{StartTime=10}
 - 改变{Subject=电影院} {SlotAttribute=位置}
-- 改变{Subject=delevelopmental 午餐日程安排} {StartDate=明天}
+- 改变{Subject=delevelopmental 午餐日程} {StartDate=明天}
 - 改变{Subject=牙医预约}
-- 改变{Subject=牙医约会}自{MoveLaterTimeSpan=一个小时}后
+- 改变{Subject=牙医 appt}自{MoveLaterTimeSpan=一个小时}后
 


### PR DESCRIPTION
Translation service started returning a slightly modified text for zh-CN. This change updates the impacted ludown tests so the expected translated content matches what's returned by the service call. 