### PR TITLE
[DO NOT MERGE] Add --noDecorate so LUIS/Dispatch names don't get prepended

### DIFF
--- a/packages/MSBot/src/msbot-clone-services.ts
+++ b/packages/MSBot/src/msbot-clone-services.ts
@@ -51,11 +51,13 @@ interface ICloneArgs {
     appSecret: string;
     args: string[];
     force: boolean;
+    noDecorate: boolean;
 }
 
 program
     .name('msbot clone services')
     .option('-n, --name <name>', 'name of new bot')
+    .option('--noDecorate', 'do not prepend name of bot for names')
     .option('-f, --folder <folder>', 'path to folder containing exported resources')
     .option('-l, --location <location>', 'location to create the bot service in (westus, ...)')
     .option('--luisAuthoringKey <luisAuthoringKey>', 'authoring key from the appropriate luisAuthoringRegion for luis resources')
@@ -802,7 +804,7 @@ async function importAndTrainLuisApp(luisResource: IResource): Promise<LuisServi
     let luisService: LuisService;
     const luisAuthoringRegion = regionToLuisAuthoringRegionMap[args.location];
 
-    let luisAppName = `${args.name}_${luisResource.name}`;
+    let luisAppName = args.noDecorate ? `${luisResource.name}` : `${args.name}_${luisResource.name}`;
     let svcOut = <ILuisService>await runCommand(`luis import application --region ${luisAuthoringRegion} --appName "${luisAppName}" --in ${luisPath} --authoringKey ${args.luisAuthoringKey} --msbot`,
         `Creating and importing LUIS application [${luisAppName}]`);
     luisService = new LuisService(svcOut);


### PR DESCRIPTION
Fixes #https://github.com/Microsoft/botbuilder-tools/issues/667

## Proposed Changes
Add --noDecorate switch so bot.config files don't get pre-pended with the bot name.

## Testing
@tomlm/@stevengum Need some help here.