### PR TITLE
bump version and remove spaces at start of line in readme

### DIFF
--- a/packages/LUISGen/src/npm/package.json
+++ b/packages/LUISGen/src/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luisgen",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "LUISGen is a tool for generating C# class or Typescript interface for a LUIS app to make consuming LUIS output easier.",
   "repository": {
     "type": "git",

--- a/packages/LUISGen/src/npm/readme.md
+++ b/packages/LUISGen/src/npm/readme.md
@@ -1,12 +1,12 @@
- # LUISGen Command Line Tool 
- [![npm version](https://badge.fury.io/js/luisgen.svg)](https://badge.fury.io/js/luisgen)
+# LUISGen Command Line Tool 
+[![npm version](https://badge.fury.io/js/luisgen.svg)](https://badge.fury.io/js/luisgen)
 
- LUISGen is a tool for generating a strongly typed C# class or typescript
- interface to make consuming LUIS output easier. This enables build-time error
- checking and intellisense against the entities which are defined in your LUIS 
- application model.
+LUISGen is a tool for generating a strongly typed C# class or typescript
+interface to make consuming LUIS output easier. This enables build-time error
+checking and intellisense against the entities which are defined in your LUIS 
+application model.
 
- ## Prerequisite
+## Prerequisite
 
 This tool depends on having [DotNet Core SDK 2.1](https://www.microsoft.com/net/download) installed 
 on your system. 


### PR DESCRIPTION
readme had erroneous spaces at beginning of line causing markdown to not render correctly
bump version of package