### PR TITLE
Remove const for intercept-stdout for LUIS y Ludown, Fix --help with no prefix in LUIS

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -65,17 +65,16 @@ async function runProgram() {
     args = minimist(argvFragment, { string: ['versionId'] });
     if (args._[0] == "luis")
         args._ = args._.slice(1);
-
+    if (args.prefix) {
+        intercept(function (txt) {
+            return `[${pkg.name}]\n${txt}`;
+        });
+    }
     if (args.help ||
         args.h ||
         args['!'] ||
         args._.includes('help')) {
         return help(args, process.stdout);
-    }
-    if (args.prefix) {
-        const unhook_intercept = intercept(function (txt) {
-            return `[${pkg.name}]\n${txt}`;
-        });
     }
     if (args.version || args.v) {
         return process.stdout.write(require(path.join(__dirname, '../package.json')).version + "\n");

--- a/packages/Ludown/lib/helpers.js
+++ b/packages/Ludown/lib/helpers.js
@@ -3,6 +3,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const fs = require('fs');
 const path = require('path');
 const PARSERCONSTS = require('./enums/parserconsts');
@@ -13,7 +14,6 @@ const LUISBuiltInTypes = require('./enums/luisbuiltintypes').consolidatedList;
 const NEWLINE = require('os').EOL;
 const ANY_NEWLINE = /\r\n|\r|\n/g;
 const url = require('url');
-const utils = require('./utils');
 const helpers = {
 
     /**

--- a/packages/Ludown/lib/ludown-parse-ToLuis.js
+++ b/packages/Ludown/lib/ludown-parse-ToLuis.js
@@ -3,12 +3,12 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const program = require('commander');
 const fParser = require('../lib/parser');
 const chalk = require('chalk');
 const retCode = require('../lib/enums/CLI-errors');
 const cmdEnum = require('../lib/enums/parsecommands');
-const utils = require('./utils');
 program.Command.prototype.unknownOption = function () {
     process.stderr.write(chalk.default.redBright(`\n  Unknown arguments: ${process.argv.slice(2).join(' ')}\n`));
     program.help();

--- a/packages/Ludown/lib/ludown-parse-ToQna.js
+++ b/packages/Ludown/lib/ludown-parse-ToQna.js
@@ -3,12 +3,12 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const program = require('commander');
 const fParser = require('../lib/parser');
 const chalk = require('chalk');
 const retCode = require('../lib/enums/CLI-errors');
 const cmdEnum = require('../lib/enums/parsecommands');
-const utils = require('./utils');
 program.Command.prototype.unknownOption = function () {
     process.stderr.write(chalk.default.redBright(`\n  Unknown arguments: ${process.argv.slice(2).join(' ')}\n`));
     program.help();

--- a/packages/Ludown/lib/ludown-parse.js
+++ b/packages/Ludown/lib/ludown-parse.js
@@ -3,9 +3,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const program = require('commander');
 const chalk = require('chalk');
-const utils = require('./utils');
 program.Command.prototype.unknownOption = function () {
     process.stderr.write(chalk.default.redBright(`\n  Unknown arguments: ${process.argv.slice(2).join(' ')}\n`));
     program.help();

--- a/packages/Ludown/lib/ludown-refresh.js
+++ b/packages/Ludown/lib/ludown-refresh.js
@@ -3,11 +3,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const program = require('commander');
 const chalk = require('chalk');
 const toLU = require('../lib/toLU');
 const retCode = require('../lib/enums/CLI-errors');
-const utils = require('./utils');
 program.Command.prototype.unknownOption = function () {
     process.stderr.write(chalk.default.redBright(`\n  Unknown arguments: ${process.argv.slice(2).join(' ')}\n`));
     program.help();

--- a/packages/Ludown/lib/ludown-translate.js
+++ b/packages/Ludown/lib/ludown-translate.js
@@ -3,11 +3,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const program = require('commander');
 const chalk = require('chalk');
 const translate = require('../lib/translate');
 const retCode = require('../lib/enums/CLI-errors');
-const utils = require('./utils');
 program.Command.prototype.unknownOption = function () {
     process.stderr.write(chalk.default.redBright(`\n  Unknown arguments: ${process.argv.slice(2).join(' ')}\n`));
     program.help();

--- a/packages/Ludown/lib/ludown.js
+++ b/packages/Ludown/lib/ludown.js
@@ -3,10 +3,10 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const program = require('commander');
 const chalk = require('chalk');
 const pkg = require('../package.json');
-const utils = require('./utils');
 const semver = require('semver');
 const getLatestVersion = require('latest-version');
 getLatestVersion(pkg.name, { version: `>${pkg.version}` })

--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -3,6 +3,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const LUISObjNameEnum = require('./enums/luisobjenum');
 const PARSERCONSTS = require('./enums/parserconsts');
 const builtInTypes = require('./enums/luisbuiltintypes');
@@ -22,7 +23,6 @@ const NEWLINE = require('os').EOL;
 const fetch = require('node-fetch');
 const qnaFile = require('../lib/classes/qnaFiles');
 const fileToParse = require('../lib/classes/filesToParse');
-const utils = require('./utils');
 const parseFileContentsModule = {
     /**
      * Helper function to validate parsed LUISJsonblob

--- a/packages/Ludown/lib/parser.js
+++ b/packages/Ludown/lib/parser.js
@@ -4,6 +4,7 @@
  * Licensed under the MIT License.
  */
 /*eslint no-console: ["error", { allow: ["log"] }] */
+require('./utils');
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
@@ -17,7 +18,6 @@ const exception = require('./classes/exception');
 const filesToParseClass = require('./classes/filesToParse');
 const parserObject = require('./classes/parserObject');
 const hClasses = require('./classes/hclasses');
-const utils = require('./utils');
 
 const parser = {
     /**

--- a/packages/Ludown/lib/toLU-helpers.js
+++ b/packages/Ludown/lib/toLU-helpers.js
@@ -3,6 +3,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const helperClasses = require('./classes/hclasses');
 const helpers = require('./helpers');
 const NEWLINE = require('os').EOL;

--- a/packages/Ludown/lib/toLU.js
+++ b/packages/Ludown/lib/toLU.js
@@ -3,6 +3,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
@@ -11,7 +12,6 @@ const txtfile = require('read-text-file');
 const toLUHelpers = require('./toLU-helpers');
 const helperClasses = require('./classes/hclasses');
 const exception = require('./classes/exception');
-const utils = require('./utils');
 const toLUModules = {
     /**
      * Function to take commander program object and construct markdown file for specified input

--- a/packages/Ludown/lib/translate-helpers.js
+++ b/packages/Ludown/lib/translate-helpers.js
@@ -3,6 +3,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const fetch = require('node-fetch');
 const PARSERCONSTS = require('./enums/parserconsts');
 const retCode = require('./enums/CLI-errors');
@@ -11,7 +12,6 @@ const helperClasses = require('./classes/hclasses');
 const exception = require('./classes/exception');
 const helpers = require('./helpers');
 const NEWLINE = require('os').EOL;
-const utils = require('./utils');
 const translateHelpers = {
     /**
      * Helper function to parseAndTranslate lu file content

--- a/packages/Ludown/lib/translate.js
+++ b/packages/Ludown/lib/translate.js
@@ -3,6 +3,7 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+require('./utils');
 const chalk = require('chalk');
 const fs = require('fs');
 const path = require('path');
@@ -11,7 +12,6 @@ const txtfile = require('read-text-file');
 const helpers = require('./helpers');
 const translateHelpers = require('./translate-helpers');
 const exception = require('./classes/exception');
-const utils = require('./utils');
 const translateModule = {
     /**
      * Helper function to parse, translate and write out localized lu files

--- a/packages/Ludown/lib/utils.js
+++ b/packages/Ludown/lib/utils.js
@@ -6,7 +6,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
  */
 const pkg = require('../package.json');
 const intercept = require("intercept-stdout");
-const unhook_intercept = intercept(function(txt) {
+intercept(function(txt) {
     return `${process.env.PREFIX === 'prefix' ? `[${pkg.name}] ` : ''}${txt}`;
 });
-exports.unhook_intercept = unhook_intercept;


### PR DESCRIPTION
## Proposed Changes
- Remove unused `const` for `intercept-stdout` in LUIS and Ludown files.
- Move validation for `--prefix` argument before the validation for `--help`, otherwise it will not intercept output for the `--help` output text.

## Testing
Calling `luis --help --prefix` will append the prefix to the output of the command.
The removal of the unused `const` will not modify the behavior of the code.