### PR TITLE
Ludown: parse toluis now de-dupes patterns

### DIFF
--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -706,7 +706,13 @@ const parseAndHandleIntent = function(parsedContent, chunkSplitByLine) {
                 }
 
                 if(havePatternAnyEntitiesInUtterance) {
-                    parsedContent.LUISJsonStructure.patterns.push(new helperClass.pattern(utterance, intentName));
+                    // push to patterns if it does not exist
+                    let newPattern = new helperClass.pattern(utterance, intentName);
+                    let patternExists = parsedContent.LUISJsonStructure.patterns.find(item => {
+                        return deepEqual(item, newPattern);
+                    })
+                    if (!patternExists) 
+                        parsedContent.LUISJsonStructure.patterns.push(new helperClass.pattern(utterance, intentName));
                 }
                 
             } else {

--- a/packages/Ludown/lib/parser.js
+++ b/packages/Ludown/lib/parser.js
@@ -221,6 +221,10 @@ const getOutputFolder = function(program) {
 const getFilesToParse = async function(program) {
     let filesToParse = [];
     if(program.in) {
+        // --in cannot be a folder
+        if(fs.lstatSync(program.in).isDirectory()) {
+            throw(new exception(retCode.errorCode.NO_LU_FILES_FOUND, 'Sorry, ' + program.in + ' is a folder. Use -l to pass in a folder.'));
+        }
         filesToParse.push(program.in);
     }
     if(program.lu_folder) {

--- a/packages/Ludown/test/ludown.parsefile.test.suite.js
+++ b/packages/Ludown/test/ludown.parsefile.test.suite.js
@@ -3,7 +3,8 @@
  * Licensed under the MIT License.
  */
 const parseFile = require('../lib/parseFileContents');
-
+var chai = require('chai');
+var assert = chai.assert;
 describe('With helper functions', function() {
     it('validateLUISBlob throw when duplicate entity definitions are found', function(done) {
         let luFile = `# Greeting
@@ -109,5 +110,18 @@ m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix
         parseFile.parseFile(luFile, false, 'en-us')
             .then(() => done('Test fail. validateLUISBlob did not throw when expected!'))
             .catch(() => done())
+    });
+
+    it('parseFile correctly de-dupes patterns', function(done) {
+        let luFile = `# test
+        - this is {one}
+        - this is {one}
+`;
+        parseFile.parseFile(luFile, false, 'en-us')
+            .then(res => {
+                assert.equal(res.LUISJsonStructure.patterns.length, 1);
+                done();
+            })
+            .catch(() => done('Test fail. parseFile threw when it was not expected!'))
     });
 });


### PR DESCRIPTION
Fixes #710 

## Proposed Changes
- Added code to de-dupe patterns on parse to luis command. 
- Added tests
- Added validation to ensure --in to parse command is not a folder


## Testing
- Added new tests. 