### PR TITLE
Ludown - match LUIS.ai behavior - allow phrase lists to have same name as other entity types

### DIFF
--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -72,16 +72,7 @@ const parseFileContentsModule = {
                 }
             });
         }
-        if(LUISJSONBlob.model_features.length > 0) {
-            LUISJSONBlob.model_features.forEach(function(entity) {
-                entityFound = helpers.filterMatch(entitiesList, 'name', entity.name);
-                if(entityFound.length === 0) {
-                    entitiesList.push(new helperClass.validateLUISBlobEntity(entity.name,['phraseList']));
-                } else {
-                    entityFound[0].type.push('phraseList');
-                }
-            });
-        }
+        
         // for each entityFound, see if there are duplicate definitions
         entitiesList.forEach(function(entity) {
             if(entity.type.length > 1) {

--- a/packages/Ludown/test/ludown.parsefile.test.suite.js
+++ b/packages/Ludown/test/ludown.parsefile.test.suite.js
@@ -10,11 +10,9 @@ describe('With helper functions', function() {
         let luFile = `# Greeting
 - hi {commPreference}
 
+$commPreference:simple
 $commPreference:call=
-- phone call
-
-$commPreference:phraseList
-- m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix`;
+- phone call`;
         parseFile.parseFile(luFile, false, 'en-us')
             .then(function(parsedContent) {
                 parseFile.validateLUISBlob(parsedContent.LUISJsonStructure)
@@ -22,6 +20,21 @@ $commPreference:phraseList
                     .catch(() => done())
             })
             .catch(() => done('Test fail. validateLUISBlob did not throw when expected!'))
+    });
+
+    it('validateLUISBlob does not throw when phrase list names collide with other entity names', function(done) {
+        let luFile = `# Greeting
+- hi {commPreference}
+$commPreference:simple
+$commPreference:phraseList
+- m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix`;
+        parseFile.parseFile(luFile, false, 'en-us')
+            .then(function(parsedContent) {
+                parseFile.validateLUISBlob(parsedContent.LUISJsonStructure)
+                    .then(() => done())
+                    .catch(() => done('Test fail. validateLUISBlob did not throw when expected!'))
+            })
+            .catch((err) => done('Test fail. validateLUISBlob did not throw when expected!'))
     });
 
     it('parseFile throws on invalid file refs', function(done) {


### PR DESCRIPTION
Fixes #605 

## Proposed Changes
- Removed the unique name check for phrase lists. LUIS.ai portal allows phrase list names to be same as other entity names in the application. 


## Testing
Updated existing tests and added a new test to verify removal of this validation. 