### PR TITLE
Ludown parse toluis command writes out a warning when an invalid locale code specified

### DIFF
--- a/packages/Ludown/lib/ludown-parse-ToLuis.js
+++ b/packages/Ludown/lib/ludown-parse-ToLuis.js
@@ -33,6 +33,13 @@ program
 if (process.argv.length < 4) {
     program.help();
 } else {
+    if (program.luis_culture) {
+        // List of supported LUIS.ai locales
+        const LUISLocales = ['en-us', 'fr-ca', 'zh-cn', 'nl-nl', 'fr-fr', 'de-de', 'it-it', 'ja-jp', 'ko-kr', 'pt-br', 'es-es', 'es-mx'];
+        if (!(LUISLocales.includes(program.luis_culture.toLowerCase()))) {
+            process.stderr.write(chalk.default.yellowBright(`\nWARN: Unrecognized LUIS locale. Supported locales are - ${LUISLocales.toString()} \n\n`));
+        }
+    }
     if (!program.in && !program.lu_folder) {
         process.stderr.write(chalk.default.redBright(`\n  No .lu file or folder specified.\n`));
         program.help();

--- a/packages/Ludown/test/ludown.cli.test.suite.js
+++ b/packages/Ludown/test/ludown.cli.test.suite.js
@@ -254,6 +254,17 @@ describe('The ludown cli tool', function() {
     });
     
     describe('With parse toluis command', function() {
+        it('should print a warning when an incorrect locale is specified', function(done) {
+            exec(`node ${ludown} parse toluis -c de-dex`, (error, stdout, stderr) => {
+                try {
+                    assert.equal(stderr.includes('Unrecognized LUIS locale'), true);
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            });
+        });
+
         it('should print an error when an invalid argument is passed', function(done) {
             exec(`node ${ludown} parse toluis -x`, (error, stdout, stderr) => {
                 try {


### PR DESCRIPTION
Fixes #657 

## Proposed Changes
- Added input validation to verify that the input locale is in the list of supported LUIS locales.

## Testing
- Added one new test to verify that a warning message is displayed when an incorrect locale input is detected. 

```bash
>ludown parse toluis --in examples\1.lu -c ee-fs

WARN: Unrecognized LUIS locale. Supported locales are - en-us,fr-ca,zh-cn,nl-nl,fr-fr,de-de,it-it,ja-jp,ko-kr,pt-br,es-es,es-mx
```