### PR TITLE
Added command luis get explicitlistitems 

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -330,6 +330,9 @@ async function runProgram() {
                 case "explicitlistitem":
                     result = await client.model.getExplicitListItem(args.region, args.appId, args.versionId, args.entityId, args.itemId, args);
                     break;
+                case "explicitlistitems":
+                    result = await client.model.getExplicitList(args.region, args.appId, args.versionId, args.entityId, args);
+                    break;
                 case "hierarchicalentity":
                     result = await client.model.getHierarchicalEntity(args.region, args.appId, args.versionId, args.hEntityId, args);
                     break;

--- a/packages/LUIS/bin/operations.json
+++ b/packages/LUIS/bin/operations.json
@@ -3953,7 +3953,7 @@
     },
     {
         "method": "get",
-        "methodAlias": "list",
+        "methodAlias": "get",
         "target": [
             "explicitListItems",
             "explicitlistitems"


### PR DESCRIPTION
Adding missing case for `luis get explicitListItems` command

Fixes #747 

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

  - Adding missing case for `luis get explicitListItems` command in luis.js
  - Corrected mismatched methodAlias to match command (change methodAlias from `list` to `get`
  - Doing the above bullet corrected help blurb by no longer showing `explicitListItems` when running `help` on `luis list`, and will instead show up on `help` for `luis get`
