### PR TITLE
Add missing query parameters and timing.

### DIFF
--- a/packages/LUIS/bin/help.js
+++ b/packages/LUIS/bin/help.js
@@ -177,10 +177,15 @@ function getVerbHelp(verb, output) {
 
     switch (verb) {
     case "query":
-        output.write(chalk.cyan.bold("luis query -q <querytext> --region <region>\n\n"))
-        options.table.push([chalk.cyan.bold("-q <query>"), "query to get a LUIS prediction for"]);
-        options.table.push([chalk.cyan.bold("--subscriptionKey"), "Specifies the LUIS subscriptionKey. Overrides the .luisrc value and the LUIS_SUBSCRIPTION_KEY environment variable."]);
-        options.table.push([chalk.cyan.bold("--region <region>"), "region to call"]);
+        output.write(chalk.cyan.bold("luis query --query <querytext> [--appId | --endpoint | --nologging | --region | --spellCheck | --staging | --subscriptionKey | --timezoneOffset | --timing |  --verbose]\n\n"))
+        options.table.push([chalk.cyan.bold("--query <query>"), "query to get a LUIS prediction for"]);
+        options.table.push([chalk.cyan.bold("--endpoint <endpointUrl>"), "Endpoint to use for query like https://westus.api.cognitive.microsoft.com/luis/v2.0/apps, overrides region."]);
+        options.table.push([chalk.cyan.bold("--nologging"), "Turn off query logging in LUIS."]);
+        options.table.push([chalk.cyan.bold("--spellCheck <key>"), "Check spelling using your Bing spelling key."]);
+        options.table.push([chalk.cyan.bold("--staging"), "Use the staging environtment rather than production."]);
+        options.table.push([chalk.cyan.bold("--timezoneOffset <minutes>"), "Specify the timezone offset in minutes used for resolving data time."]);
+        options.table.push([chalk.cyan.bold("--timing [iterations]"), "Perform timings on query, default is 5 iterations."]);
+        options.table.push([chalk.cyan.bold("--verbose"), "Include scores for all intents."]);
         sections.push(options);
         sections.push(configSection);
         sections.push(globalArgs);

--- a/packages/LUIS/bin/help.js
+++ b/packages/LUIS/bin/help.js
@@ -178,7 +178,7 @@ function getVerbHelp(verb, output) {
     switch (verb) {
     case "query":
         output.write(chalk.cyan.bold("luis query --query <querytext> [--appId | --endpoint | --nologging | --region | --spellCheck | --staging | --subscriptionKey | --timezoneOffset | --timing |  --verbose]\n\n"))
-        options.table.push([chalk.cyan.bold("--query <query>"), "query to get a LUIS prediction for"]);
+        options.table.push([chalk.cyan.bold("--query <query>"), "Query to analyze with LUIS prediction."]);
         options.table.push([chalk.cyan.bold("--endpoint <endpointUrl>"), "Endpoint to use for query like https://westus.api.cognitive.microsoft.com/luis/v2.0/apps, overrides region."]);
         options.table.push([chalk.cyan.bold("--nologging"), "Turn off query logging in LUIS."]);
         options.table.push([chalk.cyan.bold("--spellCheck <key>"), "Check spelling using your Bing spelling key."]);

--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -922,7 +922,7 @@ async function handleQueryCommand(args, config) {
         return help(args);
     }
     if (!args.appId) {
-        process.stderr.write(chalk.red.bold(`missing --appid\n`));
+        process.stderr.write(chalk.red.bold(`missing --appId\n`));
         return help(args);
     }
 

--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -13,6 +13,7 @@ const { LuisAuthoring } = require('../lib/luisAuthoring');
 const getOperation = require('./getOperation');
 var pos = require("cli-position");
 const Table = require('cli-table3');
+const { performance } = require('perf_hooks');
 
 function stdoutAsync(output) { return new Promise((done) => process.stdout.write(output, "utf-8", () => done())); }
 
@@ -104,13 +105,13 @@ async function runProgram() {
     args.region = args.region || serviceIn.region || config.region || "westus";
     args.cloud = args.cloud || serviceIn.cloud || config.cloud;
     args.customHeaders = { "accept-language": "en-US" };
-    
+
     validateConfig(args);
-    
+
     if (args.region == "virginia") {
         args.cloud = "us";
     }
-    
+
     let credentials = new msRest.ApiKeyCredentials({ inHeader: { "Ocp-Apim-Subscription-Key": args.authoringKey } });
     const client = new LuisAuthoring(credentials);
 
@@ -835,7 +836,7 @@ function validateConfig(config) {
 
     assert(typeof authoringKey === 'string', `The authoringKey  ${messageTail}`);
     assert(typeof region === 'string', `The region ${messageTail}`);
-    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region=='virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeuerope|australiaest]`);
+    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeuerope|australiaest]`);
 }
 
 /**
@@ -915,13 +916,12 @@ async function validateArguments(args, operation) {
 }
 
 async function handleQueryCommand(args, config) {
-    let query = args.q || args.question;
+    let query = args.q || args.query;
     if (!query) {
         process.stderr.write(chalk.red.bold(`missing -q\n`));
         return help(args);
     }
-    let appId = args.appId || config.appId;
-    if (!appId) {
+    if (!args.appId) {
         process.stderr.write(chalk.red.bold(`missing --appid\n`));
         return help(args);
     }
@@ -931,27 +931,71 @@ async function handleQueryCommand(args, config) {
         process.stderr.write(chalk.red.bold(`missing --subscriptionKey\n`));
         return help(args);
     }
-    let region = args.region || config.region;
-    if (!region) {
-        process.stderr.write(chalk.red.bold(`missing --region\n`));
-        return help(args);
+    let uri;
+    if (args.endpoint) {
+        uri = `${args.endpoint}/${args.appId}`;
+    } else {
+        let region = args.region || config.region;
+        if (region) {
+            uri = `https://${region}.api.cognitive.microsoft.com/luis/v2.0/apps/${args.appId}`;
+        }
+        else {
+            process.stderr.write(chalk.red.bold(`missing --region or --endpointBasePath\n`));
+            return help(args);
+        }
     }
 
-    if (query && appId && subscriptionKey && region) {
+    if (query && subscriptionKey && uri) {
+        var qargs = {
+            log: !args.nologging,
+            staging: args.staging,
+            "subscription-key": `${subscriptionKey}`,
+            verbose: args.verbose,
+            q: `${query}`
+        };
+        if (args.spellCheck) {
+            qargs.spellCheck = true;
+            qargs["bing-spell-check-subscription-key"] = args.spellCheck;
+        }
+        if (args.timezoneOffset) {
+            qargs.timezoneOffset = args.timezoneOffset;
+        }
         var options = {
-            uri: `https://${region}.api.cognitive.microsoft.com/luis/v2.0/apps/${appId}`,
+            uri: uri,
             method: "GET",
-            qs: {  // Query string like ?key=value&...
-                "subscription-key": `${subscriptionKey}`,
-                verbose: true,
-                timezoneOffset: 0,
-                q: `${query}`
-            },
+            qs: qargs,
             json: true
         }
-
-        let result = await request(options);
-        await stdoutAsync(JSON.stringify(result, null, 2) + "\n");
+        let timings = args.t || args.timing;
+        if (args.timing) {
+            let samples = typeof timings === 'boolean' ? 5 : timings;
+            let total = 0.0;
+            let sq = 0.0;
+            let min = Number.MAX_VALUE;
+            let max = Number.MIN_VALUE;
+            let values = [];
+            for (i = 0; i <= samples; ++i) {
+                let start = performance.now();
+                let result = await request(options);
+                let elapsed = performance.now() - start;
+                console.log(`${i}: ${elapsed} ms`);
+                if (i > 0) {
+                    total += elapsed;
+                    sq += elapsed * elapsed;
+                    if (elapsed > max) max = elapsed;
+                    if (elapsed < min) min = elapsed;
+                    values.push(elapsed);
+                }
+            }
+            values.sort((a, b) => a - b);
+            let variance = (sq - (total * total / samples)) / (samples - 1);
+            let p95 = values[Math.floor((samples - 1) * 0.95)];
+            console.log(`Timing after 1st: [${min} ms, ${total / samples} ms, ${max} ms], stddev ${Math.sqrt(variance)} ms, P95 ${p95} ms`)
+        }
+        else {
+            let result = await request(options);
+            await stdoutAsync(JSON.stringify(result, null, 2) + "\n");
+        }
         return;
     }
     return help(args);

--- a/packages/LUIS/package-lock.json
+++ b/packages/LUIS/package-lock.json
@@ -1014,6 +1014,11 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "perf_hooks": {
+      "version": "0.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/perf_hooks/-/perf_hooks-0.0.1.tgz",
+      "integrity": "sha1-JT5+GLcfzAOQ/Tr7LNfPFoXfBAw="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",

--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -50,13 +50,14 @@
     "latest-version": "^4.0.0",
     "minimist": "^1.2.0",
     "ms-rest-js": "^1.0.455",
-    "tslib": "^1.9.3",
     "node-fetch": "^2.0.0",
+    "perf_hooks": "0.0.1",
     "read-text-file": "^1.1.0",
     "readline-sync": "^1.4.9",
     "request": "^2.88.0",
     "request-promise": "^4.2.2",
     "semver": "^5.5.1",
+    "tslib": "^1.9.3",
     "window-size": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
The -query command was missing a number of parameters.  Also added the ability to specify an explicit endpoint in order to be able to query containers and the ability to do basic query timings.

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->