### PR TITLE
Delete wrong option and Add cosmosDB example 

### DIFF
--- a/packages/MSBot/docs/add-services.md
+++ b/packages/MSBot/docs/add-services.md
@@ -133,6 +133,11 @@ With the following options
 | --prefix                              | Append [msbot] prefix to all messages                   |
 | -h, --help                            | output usage information                                |
 
+An example:
+```shell
+msbot connect cosmosdb -n <COSMOS-DB-NAME> -t <TENANT-ID> -s <SUBSCRIPTION-ID> -r <RESOURCE-GROUP-NAME> --serviceName <COSMOS-DB-NAME> -e <COSMOSDB-ENDPOINT> -d <DB-NAME> -c <COLLECTION-NAME>
+```
+
 ### Connecting to a Endpoint Service  
 
 To connect your bot to localhost server:

--- a/packages/MSBot/docs/add-services.md
+++ b/packages/MSBot/docs/add-services.md
@@ -123,8 +123,7 @@ With the following options
 | -t, --tenantId <tenantId>             | Azure Tenant id (either GUID or xxx.onmicrosoft.com)    |
 | -s, --subscriptionId <subscriptionId> | Azure Subscription Id                                   |
 | -r, --resourceGroup <resourceGroup>   | Azure resource group name                               |
-| --serviceName <serviceName>           | Azure service name                                      |
-| --connectionString <connectionString> | CosmosDB connection string                              |
+| --serviceName <serviceName>           | Azure service name                                      |                         
 | -d, --database <database>             | CosmosDB database name                                  |
 | -c, --collection <collection>         | CosmosDB collection name                                |
 | -b, --bot <path>                      | path to bot file.                                       |


### PR DESCRIPTION
1. Delete wrong option "--connectionString"
![image](https://user-images.githubusercontent.com/16282358/48987260-baec4180-f160-11e8-9184-47e22d9cb77b.png)

2. Add cosmosDB Example
```shell
msbot connect cosmosdb -n <COSMOS-DB-NAME> -t <TENANT-ID> -s <SUBSCRIPTION-ID> -r <RESOURCE-GROUP-NAME> --serviceName <COSMOS-DB-NAME> -e <COSMOSDB-ENDPOINT> -d <DB-NAME> -c <COLLECTION-NAME>
```