### PR TITLE
fix up the user-agent for luis and qnamaker as package name/version

### DIFF
--- a/packages/LUIS/src/luisAuthoringContext.ts
+++ b/packages/LUIS/src/luisAuthoringContext.ts
@@ -5,9 +5,9 @@
  */
 
 import * as msRest from "ms-rest-js";
+import * as os from 'os';
 
-const packageName = "luis-apis";
-const packageVersion = "4.0.0";
+const pjson: any = require('../package.json');
 
 export class LuisAuthoringContext extends msRest.ServiceClient {
   credentials: msRest.ServiceClientCredentials;
@@ -32,6 +32,14 @@ export class LuisAuthoringContext extends msRest.ServiceClient {
     this.requestContentType = "application/json; charset=utf-8";
     this.credentials = credentials;
 
-    this.addUserAgentInfo(`${packageName}/${packageVersion}`);
+    this.addUserAgentInfo(this.getUserAgent());
+  }
+
+  private getUserAgent() : string {
+    const packageUserAgent = `${pjson.name}/${pjson.version}`;
+    const platformUserAgent = `(${os.arch()}-${os.type()}-${os.release()}; Node.js,Version=${process.version})`;
+    const userAgent = `${packageUserAgent} ${platformUserAgent}`;
+    
+    return userAgent;
   }
 }

--- a/packages/QnAMaker/lib/api/serviceBase.js
+++ b/packages/QnAMaker/lib/api/serviceBase.js
@@ -2,9 +2,10 @@
  * Copyright(c) Microsoft Corporation.All rights reserved.
  * Licensed under the MIT License.
  */
+const os = require('os');
 const { insertParametersFromObject } = require('../utils/insertParametersFromObject');
 const deriveParamsFromPath = require('../utils/deriveParamsFromPath');
-const packageJSON = require('../../package');
+const pjson = require('../../package.json');
 
 /**
  * Base class for all services
@@ -54,6 +55,7 @@ class ServiceBase {
         // Order is important since we want to allow the user to
         // override their config with the data in the params object.
         params = Object.assign({}, (dataModel || {}), { kbId }, params);
+        
         ServiceBase.validateParams(tokenizedUrl, params);
 
         let URL = insertParametersFromObject(tokenizedUrl, params);
@@ -67,6 +69,7 @@ class ServiceBase {
                 URL += !isNaN(+skip) ? `&take=${~~take}` : `take=${~~take}`;
             }
         }
+        
         const body = dataModel ? JSON.stringify(dataModel) : undefined;
         if (params.debug) {
             console.log(`${method.toUpperCase()} ${URL}`);
@@ -75,6 +78,9 @@ class ServiceBase {
             if (body)
                 console.log(body);
         }
+
+        console.log(URL);
+
         return fetch(URL, { headers, method, body });
     }
 
@@ -86,9 +92,17 @@ class ServiceBase {
     get commonHeaders() {
         return {
             'Content-Type': 'application/json',
-            'User-Agent': `botbuilder/cli/qnamaker/${packageJSON.version}`
+            'User-Agent': this.getUserAgent()
         };
     }
+
+    getUserAgent() {
+        const packageUserAgent = `${pjson.name}/${pjson.version}`;
+        const platformUserAgent = `(${os.arch()}-${os.type()}-${os.release()}; Node.js,Version=${process.version})`;
+        const userAgent = `${packageUserAgent} ${platformUserAgent}`;
+        
+        return userAgent;
+      }
 }
 
 /**


### PR DESCRIPTION
Sets (or appends) the user-agent for LUIS and QnAMaker as follows:

    **package-name/package-version (os-platform; node-platform)**

for example _on my machine_ running LUIS I get a full user-agent as follows:

'Node/v10.9.0 (x64-Windows_NT-10.0.17763) ms-rest-js/0.1.0 **luis-apis/2.1.0 (x64-Windows_NT-10.0.17763; Node.js,Version=v10.9.0)** azure-sdk-for-js'

and for qnamaker I get:

'**qnamaker/1.0.33 (x64-Windows_NT-10.0.17763; Node.js,Version=v10.9.0)**'

