### PR TITLE
user agent for LUIS cli

### DIFF
--- a/packages/LUIS/src/luisAuthoringContext.ts
+++ b/packages/LUIS/src/luisAuthoringContext.ts
@@ -5,9 +5,9 @@
  */
 
 import * as msRest from "ms-rest-js";
+import * as os from 'os';
 
-const packageName = "luis-apis";
-const packageVersion = "4.0.0";
+const pjson: any = require('../package.json');
 
 export class LuisAuthoringContext extends msRest.ServiceClient {
   credentials: msRest.ServiceClientCredentials;
@@ -32,6 +32,14 @@ export class LuisAuthoringContext extends msRest.ServiceClient {
     this.requestContentType = "application/json; charset=utf-8";
     this.credentials = credentials;
 
-    this.addUserAgentInfo(`${packageName}/${packageVersion}`);
+    this.addUserAgentInfo(this.getUserAgent());
+  }
+
+  private getUserAgent() : string {
+    const packageUserAgent = `${pjson.name}/${pjson.version}`;
+    const platformUserAgent = `(${os.arch()}-${os.type()}-${os.release()}; Node.js,Version=${process.version})`;
+    const userAgent = `${packageUserAgent} ${platformUserAgent}`;
+    
+    return userAgent;
   }
 }


### PR DESCRIPTION
Sets (or appends) the user-agent for LUIS as follows:

**package-name/package-version (os-platform; node-platform)**
for example on my machine running LUIS I get a full user-agent as follows:

'Node/v10.9.0 (x64-Windows_NT-10.0.17763) ms-rest-js/0.1.0 luis-apis/2.1.0 (x64-Windows_NT-10.0.17763; Node.js,Version=v10.9.0) azure-sdk-for-js'

