### PR TITLE
MSBot: Remove bot-name prefix from LUIS applications created via msbot clone services

### DIFF
--- a/packages/MSBot/src/msbot-clone-services.ts
+++ b/packages/MSBot/src/msbot-clone-services.ts
@@ -53,7 +53,7 @@ interface ICloneArgs {
     appSecret: string;
     args: string[];
     force: boolean;
-    noDecorate: boolean;
+    decorate: boolean;
     codeDir: string;
     projFile: string;
 }
@@ -972,7 +972,8 @@ async function importAndTrainLuisApp(luisResource: IResource): Promise<LuisServi
     let luisPath = path.join(args.folder, `${luisResource.id}.luis`);
     let luisService: LuisService;
     const luisAuthoringRegion = regionToLuisAuthoringRegionMap[args.location];    
-    let luisAppName = args.noDecorate ? `${luisResource.name}` : `${args.name}_${luisResource.name}`;
+    // Keeping the undocumented --decorate option for testing purposes. This way, you dont have to delete the LUIS applications during testing.
+    let luisAppName = args.decorate ? `${args.name}_${luisResource.name}`: `${luisResource.name}`;
     let svcOut = <ILuisService>await runCommand(`luis import application --region ${luisAuthoringRegion} --appName "${luisAppName}" --in ${luisPath} --authoringKey ${args.luisAuthoringKey} --msbot`,
         `Creating and importing LUIS application [${luisAppName}]`);
     luisService = new LuisService(svcOut);


### PR DESCRIPTION
Fixes #831 

## Proposed Changes
- Switched from undocumented --noDecorate to --decorate. By default, bot-name will not be prefixed to LUIS application names. 
- For testing purposes, you can pass in the --decorate option so LUIS application names are prefixed with bot-name. 


## Testing
Verified that by default, LUIS app names are not prefixed with bot name. 
Verified that cafebot nodejs sample deploys and works E2E with this fix. 