### PR TITLE
Bump Minor versions of most tools. Details in PR.

### DIFF
--- a/packages/Chatdown/package-lock.json
+++ b/packages/Chatdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/Chatdown/package.json
+++ b/packages/Chatdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Tool for parsing chat files and outputting replayable activities",
   "main": "lib/index.js",
   "directories": {

--- a/packages/Dispatch/package-lock.json
+++ b/packages/Dispatch/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "botdispatch",
-  "version": "1.1.11",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/Dispatch/package.json
+++ b/packages/Dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botdispatch",
-  "version": "1.1.11",
+  "version": "1.2.0",
   "description": "Tool to create LUIS model to dispatch intent among different bot components (multiple LUIS, QnA, etc)",
   "scripts": {
     "start": "dotnet bin/netcoreapp2.1/Dispatch.dll"

--- a/packages/LUIS/package-lock.json
+++ b/packages/LUIS/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "luis-apis",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luis-apis",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Tooling for connectivity with LUIS APIs",
   "main": "./lib/luisAuthoring.js",
   "types": "./typing/lib/luisAuthoring.d.ts",

--- a/packages/Ludown/package-lock.json
+++ b/packages/Ludown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ludown",
-  "version": "1.0.36",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/Ludown/package.json
+++ b/packages/Ludown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludown",
-  "version": "1.0.36",
+  "version": "1.1.0",
   "description": "Command line tool to convert .lu files to LUIS JSON and QnA maker JSON files",
   "main": "lib/exports.js",
   "scripts": {

--- a/packages/MSBot/package-lock.json
+++ b/packages/MSBot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbot",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/MSBot/package.json
+++ b/packages/MSBot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbot",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "MSBot command line tool for manipulating Microsoft Bot Framework .bot files",
   "main": "bin/BotConfig.js",
   "scripts": {

--- a/packages/QnAMaker/package-lock.json
+++ b/packages/QnAMaker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qnamaker",
-  "version": "1.0.33",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/QnAMaker/package.json
+++ b/packages/QnAMaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qnamaker",
-  "version": "1.0.33",
+  "version": "1.1.0",
   "description": "Tooling for connectivity with the QnA Maker APIs",
   "main": "lib/api/index.js",
   "bin": {


### PR DESCRIPTION
Bumps Minor version of the following tools: 
1. QnAMaker (-> 1.1.0)
2. MSBot (-> 4.3.0)
3. LuDown (-> 1.1.0)
4. Chatdown (-> 1.1.0)
5. botdispatch (-> 1.2.0)
6. Luis-apis (-> 2.2.0)