### PR TITLE
msbot: change the az cli requirements

### DIFF
--- a/packages/MSBot/package.json
+++ b/packages/MSBot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbot",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "MSBot command line tool for manipulating Microsoft Bot Framework .bot files",
   "main": "bin/BotConfig.js",
   "scripts": {

--- a/packages/MSBot/src/msbot-clone-services.ts
+++ b/packages/MSBot/src/msbot-clone-services.ts
@@ -22,8 +22,10 @@ const opn = require('opn');
 const commandExistsSync = require('command-exists').sync;
 const exec = util.promisify(child_process.exec);
 
-const BOTSERVICEMINVERSION = '(0.4.3)';
-const AZCLIMINVERSION = '(2.0.52)'; // This corresponds to the AZ CLI version that shipped in line with Bot Builder 4.2 release (December 2018).
+const BOTSERVICEMINVERSION = '(0.1.3)'; // This corresponds to the current botservice version with Azure-cli (2.0.53)
+                                        // TODO: Remove this as this vesion always corresponds with the AZ CLI version. 
+                                        // Otherwise this should instead be "BOTSERVICEEXTENSIONMINVERSION" and msbot should exec(`az extension list`) to find the current extension number.
+const AZCLIMINVERSION = '(2.0.53)'; // This corresponds to the AZ CLI version that shipped after the Bot Builder 4.2 release (December 2018).
 // Bot service extension 0.4.2 requires AZ CLI version >= 2.0.46.
 
 program.Command.prototype.unknownOption = (flag: string): void => {


### PR DESCRIPTION
Fixes: Unlocks users so that they are able to use the latest AZ CLI with the msbot 4.3.2 (not released yet)

## Proposed Changes
  - Bump the version of `msbot` to 4.3.2.
  - Changes min AZ CLI requirements
  - Change botservice version requirement to use the version released with the core AZ CLI

## Testing
Used `msbot clone` to deploy a bot.