### PR TITLE
msbot: revert `msbot --version`

### DIFF
--- a/packages/MSBot/src/msbot.ts
+++ b/packages/MSBot/src/msbot.ts
@@ -36,7 +36,7 @@ program.Command.prototype.unknownOption = (flag: string): void => {
 };
 
 program
-    .version(pkg.version, '-v, --version')
+    .version(pkg.version, '-v, --Version')
     .description(`The msbot program makes it easy to manipulate .bot files for Microsoft Bot Framework tools.`);
 
 program


### PR DESCRIPTION
## Proposed Changes
- Rolls back out `msbot --version` change as `--version` is a parameter for connecting LUIS and Dispatch services to bot files. (`msbot --Version` was changed to `msbot --version` in #878)