### PR TITLE
az bot publish call with wrong parameter name

### DIFF
--- a/packages/MSBot/src/msbot-clone-services.ts
+++ b/packages/MSBot/src/msbot-clone-services.ts
@@ -965,7 +965,7 @@ async function publishBot(azBot: IBotService): Promise<void> {
     let result: string | null = null;
 
     if (args.projFile) {
-        azPublishCmd += `--proj-name "${args.projFile}" `;
+        azPublishCmd += `--proj-file "${args.projFile}" `;
         result = await runCommand(azPublishCmd, `Publishing the local project ${args.projFile} to ${args.name} service`);
     } else {
         azPublishCmd += `--code-dir "${args.codeDir}" `;


### PR DESCRIPTION
Changed from --proj-name to --proj-file which is the value used by az bot publish

Fixes #883 <!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

  - Changed from --proj-name to --proj-file which is the value used by az bot publish

## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->