### PR TITLE
LuDown Disable test: Key is expired, disable dependent tests.

### DIFF
--- a/packages/Ludown/test/ludown.parsetranslate.test.suite.js
+++ b/packages/Ludown/test/ludown.parsetranslate.test.suite.js
@@ -9,7 +9,8 @@ const translate = require('../lib/translate-helpers');
 const retCode = require('../lib/enums/CLI-errors');
 const helpers = require('../lib/helpers');
 const NEWLINE = require('os').EOL;
-const TRANSLATE_KEY = process.env.TRANSLATOR_KEY;
+const TRANSLATE_KEY2 = process.env.TRANSLATOR_KEY;
+const TRANSLATE_KEY = null;
 
 describe('With the parseAndTranslate method', function() {
     it('Translating comments can be skipped', function(done) {
@@ -23,7 +24,7 @@ describe('With the parseAndTranslate method', function() {
     });
 
     
-    it('QnA content is translated correctly', function(done) {
+    xit('QnA content is translated correctly', function(done) {
         if (!TRANSLATE_KEY) {
             this.skip();
         }
@@ -36,7 +37,7 @@ describe('With the parseAndTranslate method', function() {
     });
 
     
-    it('Phrase list entity references are translated correctly', function(done) {
+    xit('Phrase list entity references are translated correctly', function(done) {
         if (!TRANSLATE_KEY) {
             this.skip();
         }


### PR DESCRIPTION
LuDown uses a key which appears to have just expired.  This will temporarily disable these tests until we can refresh the key.