### PR TITLE
LUISGen - C# generated class partial

### DIFF
--- a/packages/LUISGen/src/CSharp.cs
+++ b/packages/LUISGen/src/CSharp.cs
@@ -25,7 +25,7 @@ namespace {space}
             w.Indent();
 
             // Main class
-            w.IndentLine($"public class {className}: IRecognizerConvert");
+            w.IndentLine($"public partial class {className}: IRecognizerConvert");
             w.IndentLine("{");
             w.Indent();
 

--- a/packages/LUISGen/tests/LUISGenTest/Contoso_App.cs
+++ b/packages/LUISGen/tests/LUISGenTest/Contoso_App.cs
@@ -10,7 +10,7 @@ using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.AI.Luis;
 namespace Microsoft.Bot.Builder.Ai.LUIS.Tests
 {
-    public class Contoso_App: IRecognizerConvert
+    public partial class Contoso_App: IRecognizerConvert
     {
         public string Text;
         public string AlteredText;


### PR DESCRIPTION
Fixes #939 

## Proposed Changes
LuisGen returns a .NET class which needs to be routinely re-generated as the underlying LUIS model changes. In some scenarios, it may be necessary to change or extend the class for custom behaviours, but the problem is that any changes get overwritten when you next generate the class using LuisGen. The standard pattern to address this is using partial classes.

## Testing
Verified that the generated C# class contains the partial keyword.