### PR TITLE
Fix the add app operation

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -137,7 +137,7 @@ async function runProgram() {
                 case "app":
                 case "application":
                     result = await client.apps.add(args.region, args.cloud, requestBody, args);
-                    result = await client.apps.get(args.region, args.cloud, result, args);
+                    result = await client.apps.get(args.region, args.cloud, result.body, args);
 
                     // Write output to console and return
                     await writeAppToConsole(config, args, requestBody, result);
@@ -407,7 +407,7 @@ async function runProgram() {
                 case "version":
                     result = await client.versions.importMethod(args.region, args.cloud, args.appId, requestBody, args);
                     if (args.msbot) {
-                        let version = result.version;
+                        let version = result.body;
                         result = await client.apps.get(args.region, args.cloud, args.appId || args.applicationId || config.applicationId, args);
                         result.version = version;
 


### PR DESCRIPTION
Fixes #937

## Proposed Changes
  - There are multiple APIs that return their results as JSON strings. These APIs responses are then converted to objects with a property `body` that contains the actual response. To fix the issue, we should reference `result.body` instead of the result directly.

![image](https://user-images.githubusercontent.com/47255273/52205372-8347f700-287f-11e9-8028-b3c123cfded2.png)
