### PR TITLE
Add troubleshooting section

### DIFF
--- a/packages/Dispatch/readme.md
+++ b/packages/Dispatch/readme.md
@@ -324,3 +324,13 @@ To reset registry:
 ```shell
 npm config set registry https://registry.npmjs.org/
 ```
+
+# Troubleshooting
+
+If you are using the Dispatch command line tool in Azure Pipelines with a [Microsoft-hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent), you may encounter the following error:
+
+> `Unable to install/use dotnet framework`
+
+To fix this, make sure you are using the correct agent pool. In order to successfully run the .NET commands that Dispatch relies on, you will need to use Visual Studio 2017 on Windows Server 2016 (`vs2017-win2016`). In the web UI, you would select "Hosted VS2017":
+
+![azurepipelinesagentpoolvmimages](https://user-images.githubusercontent.com/41968495/52246146-8ea81c00-2899-11e9-8ed1-5a0347ad12a5.jpg)

--- a/packages/Dispatch/readme.md
+++ b/packages/Dispatch/readme.md
@@ -305,6 +305,16 @@ JS Sample: https://github.com/Microsoft/BotBuilder-Samples/tree/master/samples/j
 
 Tutorial: https://docs.microsoft.com/en-us/azure/bot-service/bot-builder-tutorial-dispatch
 
+# Troubleshooting
+
+If you are using the Dispatch command line tool in Azure Pipelines with a [Microsoft-hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent), you may encounter the following error:
+
+> `Unable to install/use dotnet framework`
+
+To fix this, make sure you are using the correct agent pool. In order to successfully run the .NET commands that Dispatch relies on, you will need to use Visual Studio 2017 on Windows Server 2016 (`vs2017-win2016`). In the web UI, you would select "Hosted VS2017":
+
+![azurepipelinesagentpoolvmimages](https://user-images.githubusercontent.com/41968495/52246146-8ea81c00-2899-11e9-8ed1-5a0347ad12a5.jpg)
+
 ## Nightly builds
 
 Nightly builds are based on the latest development code which means they may or may not be stable and probably won't be documented. These builds are better suited for more experienced users and developers although everyone is welcome to give them a shot and provide feedback.
@@ -324,13 +334,3 @@ To reset registry:
 ```shell
 npm config set registry https://registry.npmjs.org/
 ```
-
-# Troubleshooting
-
-If you are using the Dispatch command line tool in Azure Pipelines with a [Microsoft-hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent), you may encounter the following error:
-
-> `Unable to install/use dotnet framework`
-
-To fix this, make sure you are using the correct agent pool. In order to successfully run the .NET commands that Dispatch relies on, you will need to use Visual Studio 2017 on Windows Server 2016 (`vs2017-win2016`). In the web UI, you would select "Hosted VS2017":
-
-![azurepipelinesagentpoolvmimages](https://user-images.githubusercontent.com/41968495/52246146-8ea81c00-2899-11e9-8ed1-5a0347ad12a5.jpg)


### PR DESCRIPTION
Fixes #807

## Proposed Changes
It was suggested that the Dispatch readme should include a troubleshooting section in case people run into the "Unable to install/use dotnet framework" issue. This error occurs when trying to run a dispatch command in any Microsoft-hosted agent pool except "Hosted VS2017."