### PR TITLE
Fixes pattern entities not being created when referencing patterns in LU files

### DIFF
--- a/packages/Ludown/lib/parser.js
+++ b/packages/Ludown/lib/parser.js
@@ -406,6 +406,26 @@ const resolveReferencesInUtterances = async function(allParsedContent) {
         newUtterancesToAdd.forEach(item => luisModel.LUISJsonStructure.utterances.push(item));
         // add new patterns to the list
         newPatternsToAdd.forEach(item => luisModel.LUISJsonStructure.patterns.push(item));
+
+        newPatternsToAdd.forEach(patternObject => {
+            if(patternObject.pattern.includes('{'))
+            {
+                let entityRegex = new RegExp(/\{(.*?)\}/g);
+                let entitiesFound = patternObject.pattern.match(entityRegex);
+
+                entitiesFound.forEach(function (entity) {
+                    entity = entity.replace("{", "").replace("}", "");
+
+                    if (entity.includes(':')) {
+                        // this is an entity with role
+                        const [entityName, roleName] = entity.split(':');
+                        parseFileContents.addItemOrRoleIfNotPresent(luisModel.LUISJsonStructure, LUISObjNameEnum.PATTERNANYENTITY, entityName, [roleName])
+                    } else {
+                        parseFileContents.addItemIfNotPresent(luisModel.LUISJsonStructure, LUISObjNameEnum.PATTERNANYENTITY, entity);
+                    }
+                });
+            }
+        })
     });
 }
 /**

--- a/packages/Ludown/test/ludown.examples.test.suite.js
+++ b/packages/Ludown/test/ludown.examples.test.suite.js
@@ -26,7 +26,7 @@ function sanitizeExampleJson(fileContent) {
     return fileContent.replace(new RegExp(escapedExampleNewLine, 'g'), escapedNewLine);
 }
 
-describe('The example lu files', function() {
+describe('The example lu files', function () {
     before(function () {
         try {
             if (!fs.existsSync(PATH_TO_OUTPUT_FOLDER)) {
@@ -37,39 +37,39 @@ describe('The example lu files', function() {
         }
     });
 
-   it('refresh command successfully reconstructs a markdown file from a QnA input file with qnaDocuments section', function(done) {
+    it('refresh command successfully reconstructs a markdown file from a QnA input file with qnaDocuments section', function (done) {
         exec(`node ${ludown} refresh -q ${TEST_ROOT}/testcases/qnaDocuments.json -o ${TEST_ROOT}/output -n qnaDocuments`, () => {
             try {
                 done();
-            } catch(err) {
+            } catch (err) {
                 done(err);
             }
         });
     });
 
-    it('refresh command successfully reconstructs a markdown file from a LUIS input file with out of order entity references', function(done) {
+    it('refresh command successfully reconstructs a markdown file from a LUIS input file with out of order entity references', function (done) {
         exec(`node ${ludown} refresh -i ${TEST_ROOT}/testcases/test269-d.json -o ${TEST_ROOT}/output --skip_header -n test269-d`, () => {
             try {
                 compareFiles(TEST_ROOT + '/output/test269-d.lu', TEST_ROOT + '/verified/test269-d.lu');
                 done();
-            } catch(err) {
+            } catch (err) {
                 done(err);
             }
         });
     });
 
-    it('refresh command successfully reconstructs a markdown file from a LUIS input file', function(done) {
+    it('refresh command successfully reconstructs a markdown file from a LUIS input file', function (done) {
         exec(`node ${ludown} refresh -i ${TEST_ROOT}/verified/all.json -o ${TEST_ROOT}/output --skip_header -n allGen`, () => {
             try {
                 compareFiles(TEST_ROOT + '/output/allGen.lu', TEST_ROOT + '/verified/allGen.lu');
                 done();
-            } catch(err) {
+            } catch (err) {
                 done(err);
             }
         });
     });
 
-    it('refresh command successfully reconstructs a markdown file from QnA input file', function(done) {
+    it('refresh command successfully reconstructs a markdown file from QnA input file', function (done) {
         exec(`node ${ludown} refresh -q ${TEST_ROOT}/verified/all-qna.json -o ${TEST_ROOT}/output --skip_header -n allGenQnA`, () => {
             try {
                 compareFiles(TEST_ROOT + '/output/allGenQnA.lu', TEST_ROOT + '/verified/allGenQnA.lu');
@@ -77,11 +77,11 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     })
 
-    it('refresh command successfully writes out a markdown file from QnA and luis input files', function(done) {
+    it('refresh command successfully writes out a markdown file from QnA and luis input files', function (done) {
         exec(`node ${ludown} refresh -q ${TEST_ROOT}/verified/all-qna.json -i ${TEST_ROOT}/verified/all.json -o ${TEST_ROOT}/output --skip_header --verbose`, (error, stdout) => {
             try {
                 compareFiles(TEST_ROOT + '/output/allall-qna.lu', TEST_ROOT + '/verified/allall-qna.lu');
@@ -90,11 +90,11 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     })
 
-    it('Simple intent and utterances are parsed correctly', function(done) {
+    it('Simple intent and utterances are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/1.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/1.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/1.json')));
@@ -102,35 +102,35 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('Multiple intent and utterance definition sections are parsed correctly', function(done) {
+    it('Multiple intent and utterance definition sections are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/3.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/3.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/3.json')));
                 done();
-            } catch(err) {
+            } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('Uttearnces with labelled values are parsed correctly', function(done) {
+    it('Uttearnces with labelled values are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/4.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/4.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/4.json')));
                 done();
-            } catch (err){
+            } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('Simple entity declaration is parsed correctly', function(done) {
+    it('Simple entity declaration is parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/5.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/5.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/5.json')));
@@ -138,11 +138,11 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-             
+
         });
     });
 
-    it('Prebuilt entity types are parsed correctly', function(done) {
+    it('Prebuilt entity types are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/6.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/6.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/6.json')));
@@ -150,35 +150,35 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('Pattern.any entity types are parsed correctly', function(done) {
+    it('Pattern.any entity types are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/7.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/7.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/7.json')));
-                done();    
+                done();
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('List entity types are parsed correctly', function(done) {
+    it('List entity types are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/9.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/9.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/9.json')));
-                done(); 
+                done();
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('List entity definitions and intent definitions can be split up and will be parsed correctly', function(done) {
+    it('List entity definitions and intent definitions can be split up and will be parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/9a.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/9a.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/9a.json')));
@@ -186,11 +186,11 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('with single file references are parsed correctly', function(done) {
+    it('with single file references are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/buyChocolate.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/buyChocolate.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/buyChocolate.json')));
@@ -198,23 +198,23 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('with multiple file references are parsed correctly', function(done) {
+    it('with multiple file references are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/11.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/11.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/11.json')));
-                done(); 
+                done();
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('with mix of LUIS and QnA content is parsed correctly [LUIS]', function(done) {
+    it('with mix of LUIS and QnA content is parsed correctly [LUIS]', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/12.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/12.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/12.json')));
@@ -222,23 +222,23 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('with mix of LUIS and QnA content is parsed correctly [QnA]', function(done) {
+    it('with mix of LUIS and QnA content is parsed correctly [QnA]', function (done) {
         exec(`node ${ludown} parse toqna --in ${TEST_ROOT}/../examples/12.lu -o ${TEST_ROOT}/output -n 12qna`, () => {
             try {
-                assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/12qna.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/12qna.json'))));    
+                assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/12qna.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/12qna.json'))));
                 done();
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('all concepts of lu file definition is parsed correctly [LUIS]', function(done) {
+    it('all concepts of lu file definition is parsed correctly [LUIS]', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/../examples/all.lu -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/all.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/all.json')));
@@ -246,11 +246,11 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('all concepts of lu file definition is parsed correctly  [QnA]', function(done) {
+    it('all concepts of lu file definition is parsed correctly  [QnA]', function (done) {
         exec(`node ${ludown} parse toqna --in ${TEST_ROOT}/../examples/all.lu -o ${TEST_ROOT}/output -n all-qna`, () => {
             try {
                 assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/all-qna.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/all-qna.json'))));
@@ -258,23 +258,23 @@ describe('The example lu files', function() {
             } catch (err) {
                 done(err);
             }
-            
+
         });
     });
 
-    it('all entity types are parsed correctly', function(done) {
+    it('all entity types are parsed correctly', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/all-entity-types.lu -o ${TEST_ROOT}/output`, () => {
             try {
-                assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/all-entity-types.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/all-entity-types.json')));    
+                assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/all-entity-types.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/output/all-entity-types.json')));
                 done();
             } catch (err) {
                 done(err);
             }
-            
-        });
-    }); 
 
-    it('writes out a warning when no utterances are found for an intent', function(done){
+        });
+    });
+
+    it('writes out a warning when no utterances are found for an intent', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/missing-utterance.lu -o ${TEST_ROOT}/output --verbose`, (error, stdout) => {
             try {
                 assert.ok(stdout.includes('[WARN] No utterances found for intent: # Greeting'));
@@ -285,7 +285,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('writes out an error when invalid entity definition is found', function(done){
+    it('writes out an error when invalid entity definition is found', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/missing-utterance.lu -o ${TEST_ROOT}/output --verbose`, (error, stdout, stderr) => {
             try {
                 assert.ok(stderr.includes('Invalid entity definition'));
@@ -296,7 +296,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('writes out a warning when no synonym definitions are found for a list entity', function(done){
+    it('writes out a warning when no synonym definitions are found for a list entity', function (done) {
         exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/missing-synonyms.lu -o ${TEST_ROOT}/output --verbose`, (error, stdout) => {
             try {
                 assert.ok(stdout.includes('[WARN] No synonyms list found'));
@@ -307,7 +307,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('Successfully spits out qnamaker alterations list when specified in .lu files', function(done){
+    it('Successfully spits out qnamaker alterations list when specified in .lu files', function (done) {
         exec(`node ${ludown} parse toqna -a --in ${TEST_ROOT}/../examples/qna-alterations.lu -o ${TEST_ROOT}/output --verbose`, (error, stdout) => {
             try {
                 assert.ok(stdout.includes('Successfully wrote QnA Alterations JSON file'));
@@ -318,7 +318,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('Throws when an invalid QnA Maker alteration is specified in the input .lu file', function(done){
+    it('Throws when an invalid QnA Maker alteration is specified in the input .lu file', function (done) {
         exec(`node ${ludown} parse toqna -a --in ${TEST_ROOT}/testcases/invalid-alterations.lu -o ${TEST_ROOT}/output --verbose`, (error, stdout, stderr) => {
             try {
                 assert.ok(stderr.includes('[ERROR]: QnA alteration list value'));
@@ -329,7 +329,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('Collate can correctly merge LUIS content split across LU files', function(done){
+    it('Collate can correctly merge LUIS content split across LU files', function (done) {
         exec(`node ${ludown} parse toluis -l ${TEST_ROOT}/testcases/collate -n collated-luis -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/output/collated-luis.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/collated-luis.json')));
@@ -340,7 +340,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('Collate can correctly merge LUIS content split across LU files to generate batch test input', function(done){
+    it('Collate can correctly merge LUIS content split across LU files to generate batch test input', function (done) {
         exec(`node ${ludown} parse toluis -l ${TEST_ROOT}/testcases/collate -n collated-luis -o ${TEST_ROOT}/output -t`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/output/collated-luis_LUISBatchTest.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/collated-luis_LUISBatchTest.json')));
@@ -351,7 +351,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('Collate can correctly merge QnA content split across LU files', function(done){
+    it('Collate can correctly merge QnA content split across LU files', function (done) {
         exec(`node ${ludown} parse toqna -l ${TEST_ROOT}/testcases/collate -n collate-qna -o ${TEST_ROOT}/output`, () => {
             try {
                 assert.deepEqual(JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/output/collate-qna.json'))), JSON.parse(sanitizeExampleJson(txtfile.readSync(TEST_ROOT + '/verified/collate-qna.json'))));
@@ -362,7 +362,7 @@ describe('The example lu files', function() {
         });
     });
 
-    it('Collate can correctly merge QnA word alteration content split across LU files', function(done){
+    it('Collate can correctly merge QnA word alteration content split across LU files', function (done) {
         exec(`node ${ludown} parse toqna -l ${TEST_ROOT}/testcases/collate -n alterations -o ${TEST_ROOT}/output -a`, () => {
             try {
                 assert.deepEqual(JSON.parse(txtfile.readSync(TEST_ROOT + '/output/alterations_Alterations.json')), JSON.parse(txtfile.readSync(TEST_ROOT + '/verified/collate_Alterations.json')));
@@ -450,6 +450,33 @@ describe('The example lu files', function() {
         });
     });
 
+    it('parseFile correctly adds pattern entities for referenced patterns', function (done) {
+        exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/ref9.lu --out ref9.json -o ${TEST_ROOT}/output`, () => {
+            try {
+                const output = JSON.parse(txtfile.readSync(TEST_ROOT + '/output/ref9.json'))
+                assert(output.patterns.length === 2);
+                assert(output.patternAnyEntities.length === 1);
+                assert(output.patternAnyEntities[0].name === 'alarmTime');
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
+    it('parseFile doesnt add pattern entity for referenced patterns if same entity name exists in original file', function (done) {
+        exec(`node ${ludown} parse toluis --in ${TEST_ROOT}/testcases/ref10.lu --out ref10.json -o ${TEST_ROOT}/output`, () => {
+            try {
+                const output = JSON.parse(txtfile.readSync(TEST_ROOT + '/output/ref10.json'))
+                assert(output.patterns.length === 2);
+                assert(output.patternAnyEntities.length === 0);
+                done();
+            } catch (err) {
+                done(err);
+            }
+        });
+    });
+
     it('Nested entity references in LUIS JSON models are skipped correctly', function (done) {
         exec(`node ${ludown} refresh -i ${TEST_ROOT}/testcases/nested-luis-json.json -o ${TEST_ROOT}/output`, (error, stdout, stderr) => {
             try {
@@ -471,5 +498,5 @@ describe('The example lu files', function() {
             }
         });
     });
-    
+
 });

--- a/packages/Ludown/test/testcases/ref10.lu
+++ b/packages/Ludown/test/testcases/ref10.lu
@@ -1,0 +1,4 @@
+# All
+- [all utterances in the .lu file](./8.lu#DeleteAlarm)
+
+$alarmTime:Simple

--- a/packages/Ludown/test/testcases/ref9.lu
+++ b/packages/Ludown/test/testcases/ref9.lu
@@ -1,0 +1,2 @@
+# All
+- [all utterances in the .lu file](./8.lu#DeleteAlarm)


### PR DESCRIPTION
Fixes #855

## Proposed Changes
- Ensures that pattern entities are passed/created to the source file from the referenced file along with the patterns,
## Testing
- Tests that pattern entities are passed/created to the source file.
- Tests that pattern entities are not passed/created if they already had existed in the source file.