### PR TITLE
ServiceVersion parsing and comparison of versions in msbot-clone-service

### DIFF
--- a/packages/MSBot/src/msbot-clone-service-version.ts
+++ b/packages/MSBot/src/msbot-clone-service-version.ts
@@ -1,20 +1,22 @@
 export class ServiceVersion {
     constructor(version: string) {
-        const versionPattern = /([0-9]+)\.([0-9]+)\.([0-9]+)/;
-        const versions = versionPattern.exec(version) || ['0', '0', '0', '0'];
+        const versionPattern = /([0-9]+)(?:\.([0-9]+)(?:\.([0-9]+)(?:\.([0-9]+))?)?)?/;
+        const versions = versionPattern.exec(version) || ['0', '0', '0', '0', '0'];
         this.major = parseInt(versions[1]);
-        this.minor = parseInt(versions[2]);
-        this.patch = parseInt(versions[3]);
+        this.minor = parseInt(versions[2]) || 0;
+        this.patch = parseInt(versions[3]) || 0;
+        this.revision = parseInt(versions[4]) || 0;
     }
 
     public major: number;
     public minor: number;
     public patch: number;
+    public revision: number;
 
     public isOlder(version: ServiceVersion): boolean {
 
-        let thisVersion: number[] = [this.major, this.minor, this.patch];
-        let theirVersion: number[] = [version.major, version.minor, version.patch];
+        let thisVersion: number[] = [this.major, this.minor, this.patch, this.revision];
+        let theirVersion: number[] = [version.major, version.minor, version.patch, version.revision];
 
         for (let i = 0; i < thisVersion.length; i++) {
             if (thisVersion[i] < theirVersion[i]) {

--- a/packages/MSBot/src/msbot-clone-service-version.ts
+++ b/packages/MSBot/src/msbot-clone-service-version.ts
@@ -1,0 +1,29 @@
+export class ServiceVersion {
+    constructor(version: string) {
+        const versionPattern = /([0-9]+)\.([0-9]+)\.([0-9]+)/;
+        const versions = versionPattern.exec(version) || ['0', '0', '0', '0'];
+        this.major = parseInt(versions[1]);
+        this.minor = parseInt(versions[2]);
+        this.patch = parseInt(versions[3]);
+    }
+
+    public major: number;
+    public minor: number;
+    public patch: number;
+
+    public isOlder(version: ServiceVersion): boolean {
+
+        let thisVersion: number[] = [this.major, this.minor, this.patch];
+        let theirVersion: number[] = [version.major, version.minor, version.patch];
+
+        for (let i = 0; i < thisVersion.length; i++) {
+            if (thisVersion[i] < theirVersion[i]) {
+                return true;
+            }
+            if (thisVersion[i] > theirVersion[i]) {
+                return false;
+            }
+        }
+        return false;
+    }
+}

--- a/packages/MSBot/src/msbot-clone-services.ts
+++ b/packages/MSBot/src/msbot-clone-services.ts
@@ -17,6 +17,8 @@ import * as uuid from 'uuid';
 import { spawnAsync } from './processUtils';
 import { logAsync } from './stdioAsync';
 import { luisPublishRegions, RegionCodes, regionToAppInsightRegionNameMap, regionToLuisAuthoringRegionMap, regionToLuisPublishRegionMap, regionToSearchRegionMap } from './utils';
+import  { ServiceVersion  } from './msbot-clone-service-version'
+
 const Table = require('cli-table3');
 const opn = require('opn');
 const commandExistsSync = require('command-exists').sync;
@@ -1215,34 +1217,4 @@ async function sleep(seconds: number) {
 
 function sleepOneSecond() {
     return new Promise(resolve => setTimeout(resolve, 1000));
-}
-
-class ServiceVersion {
-    constructor(version: string) {
-        const versionPattern = /([0-9]+)\.([0-9]+)\.([0-9]+)\)/;
-        const versions = versionPattern.exec(version) || ['0', '0', '0', '0'];
-        this.major = parseInt(versions[1]);
-        this.minor = parseInt(versions[2]);
-        this.patch = parseInt(versions[3]);
-    }
-
-    public major: number;
-    public minor: number;
-    public patch: number;
-
-    public isOlder(version: ServiceVersion): boolean {
-        if (version.major == this.major && version.minor == this.minor && version.patch == this.patch)
-            return false;
-
-        if (version.major > this.major)
-            return true;
-
-        if (version.minor > this.minor)
-            return true;
-
-        if (version.patch > this.patch)
-            return true;
-
-        return false;
-    }
 }

--- a/packages/MSBot/test/msbot.clone.test.suite.js
+++ b/packages/MSBot/test/msbot.clone.test.suite.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const ServiceVersion = require('../bin/msbot-clone-service-version').ServiceVersion;
+
+describe("ServiceVersion", () => {
+
+    it("parses version strings", async () => {
+
+        versions = [
+            "1.2.3",
+            "(1.2.3)",
+            "   1.2.3\r",
+            "\t1.2.3\t"
+        ];
+
+        versions.forEach(version => {
+
+            const actual = new ServiceVersion(version);
+
+            assert.deepEqual(actual.major, 1, `Unexpected major version ${actual.major} parsed from ${version} ${JSON.stringify(actual)}`);
+            assert.deepEqual(actual.minor, 2, `Unexpected minor version ${actual.minor} parsed from ${version} ${JSON.stringify(actual)}`);
+            assert.deepEqual(actual.patch, 3, `Unexpected patch version ${actual.patch} parsed from ${version} ${JSON.stringify(actual)}`);
+        });
+    });
+
+    it('is older when version is strictly older', () => {
+        const newer = new ServiceVersion("11.22.33");
+
+        const older = ["11.22.00", "11.21.99", "10.999.999"];
+
+        older.forEach(old => {
+            const older = new ServiceVersion(old);
+            assert.ok(older.isOlder(newer), `${JSON.stringify(older)} *not* older than ${JSON.stringify(newer)}`);
+        })
+    })
+
+    it('is not older when version is strictly newer', () => {
+        const older = new ServiceVersion("11.22.33");
+
+        const newer = ["11.22.99", "11.23.0", "12.0.0"];
+
+        newer.forEach(newVersion => {
+            const actual = new ServiceVersion(newVersion);
+            assert.ok(!actual.isOlder(older), `${JSON.stringify(actual)} *is* older than ${JSON.stringify(older)}`);
+        })
+    })
+
+    it('is not older than self', () => {
+        const actual = new ServiceVersion("11.22.33");
+
+        assert.ok(!actual.isOlder(actual));
+    })
+});

--- a/packages/MSBot/test/msbot.clone.test.suite.js
+++ b/packages/MSBot/test/msbot.clone.test.suite.js
@@ -5,48 +5,93 @@ describe("ServiceVersion", () => {
 
     it("parses version strings", async () => {
 
-        versions = [
-            "1.2.3",
-            "(1.2.3)",
-            "   1.2.3\r",
-            "\t1.2.3\t"
+        versions = [{
+                text: "1",
+                major: 1,
+                minor: 0,
+                patch: 0,
+                rev: 0
+            }, {
+                text: "1.2",
+                major: 1,
+                minor: 2,
+                patch: 0,
+                rev: 0
+            }, {
+                text: "1.2.3",
+                major: 1,
+                minor: 2,
+                patch: 3,
+                rev: 0
+            },
+            {
+                text: "(1.2.3)",
+                major: 1,
+                minor: 2,
+                patch: 3,
+                rev: 0
+            },
+            {
+                text: "   1.2.3\r",
+                major: 1,
+                minor: 2,
+                patch: 3,
+                rev: 0
+            },
+            {
+                text: "\t1.2.3\t",
+                major: 1,
+                minor: 2,
+                patch: 3,
+                rev: 0
+            },
+            {
+                text: "1.2.3.4",
+                major: 1,
+                minor: 2,
+                patch: 3,
+                rev: 4
+            }
         ];
 
-        versions.forEach(version => {
+        versions.forEach(item => {
 
-            const actual = new ServiceVersion(version);
+            const actual = new ServiceVersion(item.text);
 
-            assert.deepEqual(actual.major, 1, `Unexpected major version ${actual.major} parsed from ${version} ${JSON.stringify(actual)}`);
-            assert.deepEqual(actual.minor, 2, `Unexpected minor version ${actual.minor} parsed from ${version} ${JSON.stringify(actual)}`);
-            assert.deepEqual(actual.patch, 3, `Unexpected patch version ${actual.patch} parsed from ${version} ${JSON.stringify(actual)}`);
+            assert.deepEqual(actual.major, item.major, `Unexpected major ${actual.major} parsed from ${item} ${JSON.stringify(actual)}`);
+            assert.deepEqual(actual.minor, item.minor, `Unexpected minor ${actual.minor} parsed from ${item} ${JSON.stringify(actual)}`);
+            assert.deepEqual(actual.patch, item.patch, `Unexpected patch ${actual.patch} parsed from ${item} ${JSON.stringify(actual)}`);
+            assert.deepEqual(actual.revision, item.rev, `Unexpected revision  ${actual.revision} parsed from ${item} ${JSON.stringify(actual)}`);
         });
     });
 
     it('is older when version is strictly older', () => {
-        const newer = new ServiceVersion("11.22.33");
+        const newer = new ServiceVersion("11.22.33.44");
 
-        const older = ["11.22.00", "11.21.99", "10.999.999"];
+        const older = ["10", "11.00", "11.22.00", "11.21.99", "10.999.999", "11.22.33.00", "10.99.99.99"];
 
         older.forEach(old => {
-            const older = new ServiceVersion(old);
-            assert.ok(older.isOlder(newer), `${JSON.stringify(older)} *not* older than ${JSON.stringify(newer)}`);
+            const cases = new ServiceVersion(old);
+            assert.ok(cases.isOlder(newer), `${JSON.stringify(cases)} *not* older than ${JSON.stringify(newer)}`);
         })
     })
 
     it('is not older when version is strictly newer', () => {
         const older = new ServiceVersion("11.22.33");
 
-        const newer = ["11.22.99", "11.23.0", "12.0.0"];
+        const cases = ["12", "11.23", "11.22.99", "11.23.0", "12.0.0", "11.22.33.99", "11.23.0.0", "12.0.0.0"];
 
-        newer.forEach(newVersion => {
+        cases.forEach(newVersion => {
             const actual = new ServiceVersion(newVersion);
             assert.ok(!actual.isOlder(older), `${JSON.stringify(actual)} *is* older than ${JSON.stringify(older)}`);
         })
     })
 
     it('is not older than self', () => {
-        const actual = new ServiceVersion("11.22.33");
-
-        assert.ok(!actual.isOlder(actual));
+        const cases = ["11", "11.22", "11.22.33", "11.22.33.44"]
+        cases.forEach(version => {
+            const actual = new ServiceVersion(version);
+            assert.ok(!actual.isOlder(actual));
+        });
     })
 });


### PR DESCRIPTION
Fixes #962

## Proposed Changes
This PR fixes 2 issues with `ServiceVersion` class:

1. That the regex string assumed the version from `az -v` was ending with a closing ")"
2. That the `isOlder()` function returned unexpected results.  

<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
Please see unit tests below.

Before fix:
- version string "1.2.3" would not parse because the regex pattern was `/([0-9]+)\.([0-9]+)\.([0-9]+)\)/` (as  @v-kydela spotted).
- isOlder returned unexpected results  for  {"major":11,"minor":23,"patch":0} compared to {"major":11,"minor":22,"patch":33}. I'd expect 11.22.33 is older than 11.23.0, but previous code did not. 
 
## Testing
Please run unit tests in _packages/MSBot/test/msbot.clone.test.suite.js_.
<!-- If you are adding a new feature to a library, you must include tests for your new code. --> 