### PR TITLE
Increment all tools minor version by 1 except MSbot

### DIFF
--- a/packages/Chatdown/package.json
+++ b/packages/Chatdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tool for parsing chat files and outputting replayable activities",
   "main": "lib/index.js",
   "directories": {

--- a/packages/Dispatch/package.json
+++ b/packages/Dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botdispatch",
-  "version": "1.3.3",
+  "version": "1.3.0",
   "description": "Tool to create LUIS model to dispatch intent among different bot components (multiple LUIS, QnA, etc)",
   "scripts": {
     "start": "dotnet bin/netcoreapp2.1/Dispatch.dll"

--- a/packages/Dispatch/package.json
+++ b/packages/Dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botdispatch",
-  "version": "1.2.3",
+  "version": "1.3.3",
   "description": "Tool to create LUIS model to dispatch intent among different bot components (multiple LUIS, QnA, etc)",
   "scripts": {
     "start": "dotnet bin/netcoreapp2.1/Dispatch.dll"

--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luis-apis",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Tooling for connectivity with LUIS APIs",
   "main": "./lib/luisAuthoring.js",
   "types": "./typing/lib/luisAuthoring.d.ts",

--- a/packages/LUISGen/src/npm/package.json
+++ b/packages/LUISGen/src/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luisgen",
-  "version": "2.1.2",
+  "version": "2.1.0",
   "description": "LUISGen is a tool for generating C# class or Typescript interface for a LUIS app to make consuming LUIS output easier.",
   "repository": {
     "type": "git",

--- a/packages/LUISGen/src/npm/package.json
+++ b/packages/LUISGen/src/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luisgen",
-  "version": "2.0.2",
+  "version": "2.1.2",
   "description": "LUISGen is a tool for generating C# class or Typescript interface for a LUIS app to make consuming LUIS output easier.",
   "repository": {
     "type": "git",

--- a/packages/Ludown/package.json
+++ b/packages/Ludown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludown",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Command line tool to convert .lu files to LUIS JSON and QnA maker JSON files",
   "main": "lib/exports.js",
   "scripts": {

--- a/packages/QnAMaker/package.json
+++ b/packages/QnAMaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qnamaker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Tooling for connectivity with the QnA Maker APIs",
   "main": "lib/api/index.js",
   "bin": {


### PR DESCRIPTION
Bump all minor versions for CLI tools except for msbot.

FYI @omarsourour, @ahmedaashour the version number for LUISGen is under [LUISGen/src/npm/package.json](https://github.com/Microsoft/botbuilder-tools/blob/master/packages/LUISGen/src/npm/package-lock.json) 😄 