### PR TITLE
Adding encryption flag to Msbot clone services

### DIFF
--- a/packages/MSBot/docs/export-clone.md
+++ b/packages/MSBot/docs/export-clone.md
@@ -64,6 +64,7 @@ The **msbot clone services** command depends on and requires the following tools
 | --proj-file                                 | (OPTIONAL) auto publish the local project file to created bot service |
 | --code-dir <path>                           | (OPTIONAL) auto publish the folder path to created bot service        |
 | -q, --quiet                                 | disable output                                                         |
+| -e, --encryption                            | Enables bot file encryption                                                       |
 | --verbose                                   | Show commands
 | --force                                     | Do not prompt for confirmation
 | -h, --help                                  | output usage information                                              |


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

  - This pull request adds an encryption flag to the msbot clone services.
  - Adding -e or --encryption to the command enables the bot file encryption.
  - If not added the bot file will not be encrypted.


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->