### PR TITLE
[Ludown] - improved error message when ludown is invoked without any command

### DIFF
--- a/packages/Ludown/examples/README.MD
+++ b/packages/Ludown/examples/README.MD
@@ -3,7 +3,7 @@ This folder contains several different examples of .lu files.
 ## Usage
 
 ```bash
-ludown ./Examples/all.lu
+ludown parse [toluis | toqna] --in ./Examples/all.lu
 ```
 
 ludown tool will output:

--- a/packages/Ludown/lib/ludown.js
+++ b/packages/Ludown/lib/ludown.js
@@ -45,6 +45,7 @@ getLatestVersion(pkg.name, { version: `>${pkg.version}` })
 
         if (!commands.includes(process.argv[2].toLowerCase())) {
             process.stderr.write(chalk.default.redBright(`\n  Unknown command: ${process.argv.slice(2).join(' ')}\n`));
+            process.stderr.write(chalk.default.redBright(`\n  See help text below (or ludown -h) for usage and supported commands.\n`))
             program.help();
         }
     });

--- a/packages/Ludown/test/ludown.cli.test.suite.js
+++ b/packages/Ludown/test/ludown.cli.test.suite.js
@@ -24,6 +24,18 @@ function shouldEscapeString() {
 describe('The ludown cli tool', function() {
 
     describe('with no command', function() {
+        it('should print the help contents when no command is passed', function(done) {
+            exec(`node ${ludown} examples/1.lu`, (error, stdout, stderr) => {
+                try {
+                    assert.equal(stderr.includes('See help text below (or ludown -h) for usage and supported commands'), true);
+                    done();
+                } catch(err){
+                    done(err);
+                }
+            });
+        });
+
+
         it('should print the help contents when --help is passed as an argument', function(done) {
             exec(`node ${ludown} --help`, (error, stdout) => {
                 try {


### PR DESCRIPTION
Fixes #1001

- Fixed incorrect doc under examples/readme.md
- Updated code to include better error message when ludown is invoked without any command specified


## Testing
- Added new CLI test to verify that the tool spits out helpful text when ludown is invoked without any command specified.