### PR TITLE
[Ludown] Doc fix - ':' is not supported in entity name

### DIFF
--- a/packages/Ludown/docs/lu-file-format.md
+++ b/packages/Ludown/docs/lu-file-format.md
@@ -64,6 +64,11 @@ You can define:
 - [PREBUILT](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/pre-builtentities) entities by using $PREBUILT:\<entityType\> notation. 
 - [List](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/luis-quickstart-intent-and-list-entity) entities by using $\<entityName\>:\<CanonicalValue\>**=**<List of values> notation.
 
+**Note:**
+```markdown
+Entity names in Ludown cannot include a colon ':'. E.g. $Country:Office:Simple is invalid.  
+```
+
 Here's an example: 
 
 ```markdown


### PR DESCRIPTION
Fixes #950 

- Doc update to clarify ':' is not allowed in entity names. 