### PR TITLE
fix powershell by stripping byte-order-mark

### DIFF
--- a/packages/MSBot/package-lock.json
+++ b/packages/MSBot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbot",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -20,7 +20,7 @@
     },
     "@types/get-stdin": {
       "version": "5.0.1",
-      "resolved": "https://fuselabs.pkgs.visualstudio.com/_packaging/FuseNPM/npm/registry/@types/get-stdin/-/get-stdin-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/get-stdin/-/get-stdin-5.0.1.tgz",
       "integrity": "sha1-Rq+8rwnpT+Alr6B66ZSsMWitvfM=",
       "dev": true,
       "requires": {
@@ -45,7 +45,7 @@
     "@types/readline-sync": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.3.tgz",
-      "integrity": "sha1-6sVaOdWjSZEgYsnlIWzVUMB/2cg=",
+      "integrity": "sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg==",
       "dev": true
     },
     "@types/semver": {
@@ -53,6 +53,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
       "dev": true
+    },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
     },
     "@types/uuid": {
       "version": "3.4.3",
@@ -65,13 +70,13 @@
     },
     "@types/valid-url": {
       "version": "1.0.2",
-      "resolved": "https://fuselabs.pkgs.visualstudio.com/_packaging/FuseNPM/npm/registry/@types/valid-url/-/valid-url-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.2.tgz",
       "integrity": "sha1-YPpDXOJL/VuhB7jSqAeWrq86j0U=",
       "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
@@ -324,7 +329,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "from2": {
@@ -365,7 +370,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "glob": {
@@ -419,7 +424,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbol-support-x": {
@@ -447,9 +452,9 @@
       "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -493,7 +498,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-object": {
@@ -513,7 +518,7 @@
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-wsl/-/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
     },
     "isarray": {
@@ -542,7 +547,7 @@
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -696,7 +701,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "once": {
@@ -718,7 +723,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
     },
     "p-finally": {
@@ -728,7 +733,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-timeout": {
@@ -793,7 +798,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -826,7 +831,7 @@
     },
     "read-text-file": {
       "version": "1.1.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/read-text-file/-/read-text-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-text-file/-/read-text-file-1.1.0.tgz",
       "integrity": "sha1-0MPxh2iCj5EH1huws2jue5D3GJM=",
       "requires": {
         "iconv-lite": "^0.4.17",
@@ -835,7 +840,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -849,7 +854,7 @@
     },
     "readline-sync": {
       "version": "1.4.9",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/readline-sync/-/readline-sync-1.4.9.tgz",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.9.tgz",
       "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
     },
     "registry-auth-token": {
@@ -924,11 +929,16 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
         "ansi-regex": "^3.0.0"
       }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -1029,7 +1039,7 @@
     },
     "valid-url": {
       "version": "1.0.9",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/valid-url/-/valid-url-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
       "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validator": {

--- a/packages/MSBot/package.json
+++ b/packages/MSBot/package.json
@@ -64,6 +64,7 @@
     "read-text-file": "^1.1.0",
     "readline-sync": "^1.4.9",
     "semver": "^5.5.1",
+    "strip-bom": "^3.0.0",
     "uuid": "^3.2.1",
     "valid-url": "^1.0.9",
     "validator": "^9.4.1"

--- a/packages/MSBot/src/msbot-connect-appinsights.ts
+++ b/packages/MSBot/src/msbot-connect-appinsights.ts
@@ -7,10 +7,9 @@
 import { AppInsightsService, BotConfiguration, IAppInsightsService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-connect-blob.ts
+++ b/packages/MSBot/src/msbot-connect-blob.ts
@@ -7,10 +7,9 @@
 import { BlobStorageService, BotConfiguration, IBlobStorageService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
@@ -34,7 +33,7 @@ program
     .option('--serviceName <serviceName>', 'Azure service name')
     .option('--connectionString <connectionString>', 'Blob storage connection string')
     .option('-c, --container <container>', 'blob container name')
-    
+
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
     .option('--input <jsonfile>', 'path to arguments in JSON format { id:\'\',name:\'\', ... }')
     .option('--secret <secret>', 'bot file secret password for encrypting service secrets')

--- a/packages/MSBot/src/msbot-connect-bot.ts
+++ b/packages/MSBot/src/msbot-connect-bot.ts
@@ -7,11 +7,10 @@
 import { BotConfiguration, BotService, EndpointService, IBotService, IConnectedService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import * as url from 'url';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-connect-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-connect-cosmosdb.ts
@@ -7,10 +7,10 @@
 import { BotConfiguration, CosmosDbService, ICosmosDBService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
+
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-connect-dispatch.ts
+++ b/packages/MSBot/src/msbot-connect-dispatch.ts
@@ -7,10 +7,9 @@
 import { BotConfiguration, DispatchService, IConnectedService, IDispatchService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-connect-endpoint.ts
+++ b/packages/MSBot/src/msbot-connect-endpoint.ts
@@ -7,11 +7,11 @@
 import { BotConfiguration, EndpointService, IEndpointService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import * as validurl from 'valid-url';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
+
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-connect-luis.ts
+++ b/packages/MSBot/src/msbot-connect-luis.ts
@@ -7,10 +7,9 @@
 import { BotConfiguration, ILuisService, LuisService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
@@ -32,7 +31,7 @@ program
     .option('--version <version>', 'version for the LUIS App, (example: v0.1)')
     .option('-r, --region <region>', 'region for the LUIS App, (default:westus)')
     .option('--authoringKey <authoringkey>',
-            'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
+        'authoring key for using manipulating LUIS apps via the authoring API (See http://aka.ms/luiskeys for help)')
     .option('--subscriptionKey <subscriptionKey>', '(OPTIONAL) subscription key used for querying a LUIS model\n')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')

--- a/packages/MSBot/src/msbot-connect-qna.ts
+++ b/packages/MSBot/src/msbot-connect-qna.ts
@@ -7,11 +7,10 @@
 import { BotConfiguration, IQnAService, QnaMakerService } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import * as validurl from 'valid-url';
 import { stdoutAsync } from './stdioAsync';
-import { uuidValidate } from './utils';
+import { getStdin, uuidValidate } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));
@@ -32,9 +31,9 @@ program
     .option('-n, --name <name>', 'name for the QNA knowledgebase')
     .option('-k, --kbId <kbId>', 'QnA Knowledgebase Id ')
     .option('--subscriptionKey <subscriptionKey>',
-            'Azure Cognitive Service subscriptionKey/accessKey for calling the QnA management API (from azure portal)')
+        'Azure Cognitive Service subscriptionKey/accessKey for calling the QnA management API (from azure portal)')
     .option('--endpointKey <endpointKey>',
-            'endpointKey for calling the QnA service (from https://qnamaker.ai portal or qnamaker list endpointkeys command)')
+        'endpointKey for calling the QnA service (from https://qnamaker.ai portal or qnamaker list endpointkeys command)')
     .option('--hostname <url>', 'url for private QnA service (example: https://myqna.azurewebsites.net)')
 
     .option('-b, --bot <path>', 'path to bot file.  If omitted, local folder will look for a .bot file')
@@ -92,13 +91,13 @@ async function processConnectQnaArgs(config: BotConfiguration): Promise<BotConfi
 
     if (!args.subscriptionKey || !uuidValidate(args.subscriptionKey)) {
         throw new Error('bad or missing --subscriptionKey');
-        }
+    }
     if (!args.endpointKey || !uuidValidate(args.endpointKey)) {
         throw new Error('bad or missing --endpointKey');
-        }
+    }
     if (!args.hostname || !validurl.isWebUri(args.hostname)) {
         throw new Error('bad or missing --hostname');
-        }
+    }
 
     // add the service
     const newService: QnaMakerService = new QnaMakerService({

--- a/packages/MSBot/src/msbot-update-appinsights.ts
+++ b/packages/MSBot/src/msbot-update-appinsights.ts
@@ -7,9 +7,9 @@
 import { BotConfiguration, IAppInsightsService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-update-blob.ts
+++ b/packages/MSBot/src/msbot-update-blob.ts
@@ -7,9 +7,9 @@
 import { BotConfiguration, IBlobStorageService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-update-cosmosdb.ts
+++ b/packages/MSBot/src/msbot-update-cosmosdb.ts
@@ -7,9 +7,9 @@
 import { BotConfiguration, ICosmosDBService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-update-dispatch.ts
+++ b/packages/MSBot/src/msbot-update-dispatch.ts
@@ -7,9 +7,9 @@
 import { BotConfiguration, IDispatchService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-update-endpoint.ts
+++ b/packages/MSBot/src/msbot-update-endpoint.ts
@@ -7,10 +7,10 @@
 import { BotConfiguration, EndpointService, IEndpointService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import * as validurl from 'valid-url';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-update-luis.ts
+++ b/packages/MSBot/src/msbot-update-luis.ts
@@ -7,9 +7,9 @@
 import { BotConfiguration, ILuisService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/msbot-update-qna.ts
+++ b/packages/MSBot/src/msbot-update-qna.ts
@@ -7,9 +7,9 @@
 import { BotConfiguration, IQnAService, ServiceTypes } from 'botframework-config';
 import * as chalk from 'chalk';
 import * as program from 'commander';
-import * as getStdin from 'get-stdin';
 import * as txtfile from 'read-text-file';
 import { stdoutAsync } from './stdioAsync';
+import { getStdin } from './utils';
 
 program.Command.prototype.unknownOption = (flag: string): void => {
     console.error(chalk.default.redBright(`Unknown arguments: ${flag}`));

--- a/packages/MSBot/src/utils.ts
+++ b/packages/MSBot/src/utils.ts
@@ -4,6 +4,13 @@
  */
 const pkg = require('../package.json');
 const intercept = require("intercept-stdout");
+import * as getStdinInner from 'get-stdin';
+const strip_bom = require('strip-bom');
+
+export async function getStdin() : Promise<string> {
+    var result = await getStdinInner();
+    return strip_bom(result);
+}
 
 export function uuidValidate(value: string): boolean {
     return /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/.test(value);


### PR DESCRIPTION
Fixes #961 
Powershell changes piped strings to always be UTF16 with Byte-order-mark.  We correctly dealt with bom on text files, but not on stdin streams.

## Proposed Changes
Add byte order mark processing to getStdin()

