### PR TITLE
Fixing force flag + Updating required packages

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -265,7 +265,7 @@ async function runProgram() {
                                 return;
                             }
                         }
-                        result = await client.apps.deleteMethod(args.region, args.cloud, args.appId, args.force, args);
+                        result = await client.apps.deleteMethod(args.region, args.cloud, args.appId, { force: args.force }, args);
                     }
                     break;
 


### PR DESCRIPTION
Fixes #951

## Proposed Changes
  - Fix the force flag used with the delete API. Currently the delete API call fails if the force flag is used
  - Update Packages file with the required version of typescript to make the first installation easier for new contributors