### PR TITLE
minor typo fix

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -950,7 +950,7 @@ function validateConfig(config) {
 
     assert(typeof authoringKey === 'string', `The authoringKey  ${messageTail}`);
     assert(typeof region === 'string', `The region ${messageTail}`);
-    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeuerope|australiaest]`);
+    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeurope|australiaeast]`);
 }
 
 /**

--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -950,7 +950,7 @@ function validateConfig(config) {
 
     assert(typeof authoringKey === 'string', `The authoringKey  ${messageTail}`);
     assert(typeof region === 'string', `The region ${messageTail}`);
-    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeurope|australiaeast|virginia]`);
+    assert(args.region == 'westus' || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeurope|australiaeast|virginia]`);
 }
 
 /**

--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -950,7 +950,7 @@ function validateConfig(config) {
 
     assert(typeof authoringKey === 'string', `The authoringKey  ${messageTail}`);
     assert(typeof region === 'string', `The region ${messageTail}`);
-    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeurope|australiaeast]`);
+    assert(args.region == "westus" || args.region == 'westeurope' || args.region == 'australiaeast' || args.region == 'virginia', `${args.region} is not a valid authoring region.  Valid values are [westus|westeurope|australiaeast|virginia]`);
 }
 
 /**


### PR DESCRIPTION
Fixes #1080 

## Proposed Changes

* `westeuerope` => `westeurope`
* `australiaest` => `australiaeast`
* Added `virginia` to output of acceptable args
  * The code already considers it acceptable, I just added it to the output that notifies the user of acceptable commands

This was the only location with the typo and it was in a string, so will not affect the rest of the code base.