### PR TITLE
add switch to turn on saving of .dialog files when building lu

### DIFF
--- a/packages/lubuild/src/IBuildArgs.ts
+++ b/packages/lubuild/src/IBuildArgs.ts
@@ -31,4 +31,7 @@ export interface IBuildArgs {
 
     // export endpointKeys from azure group
     endpointKeys: string;
+
+    // create .dialog files for .lu applications
+    dialogs: boolean;
 }

--- a/packages/lubuild/src/help.ts
+++ b/packages/lubuild/src/help.ts
@@ -87,6 +87,7 @@ function getHelpContents() {
             [chalk.default.cyan.bold('--folder [foldername]'), '(OPTIONAL) overrides config file with output folder name'],
             [chalk.default.cyan.bold('--force'), '(OPTIONAL) Force all models to be updated '],
             [chalk.default.cyan.bold('--endpointKeys [groupname]'), '(OPTIONAL) export all LUIS endpoint keys from the named group in the current AZ CLI subscription'],
+            [chalk.default.cyan.bold('--dialogs'), '(OPTIONAL) overrides config file with flag to generate .dialog files for recognizers that are built using lubuild (default is false)'],
         ]
     });
 

--- a/packages/lubuild/typings/lib/IBuildArgs.d.ts
+++ b/packages/lubuild/typings/lib/IBuildArgs.d.ts
@@ -10,4 +10,5 @@ export interface IBuildArgs {
     force: boolean;
     defaultLanguage: string;
     endpointKeys: string;
+    dialogs: boolean;
 }


### PR DESCRIPTION
If you aren't using dialog files you should have to deal with them.

- Added config/args setting **dialogs** which if set to true will turn on generating .dialog files for .lu models