### PR TITLE
[Ludown] Parser fixes for composites and references to ':', '=' in utterances.

### DIFF
--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -983,12 +983,12 @@ const parseAndHandleIntent = function (parsedContent, chunkSplitByLine) {
                         captureEntityName = false;
                         captureEntityValue = false;
                         captureEntityRole = false;
-                    } else if (char === '=') {
+                    } else if (char === '=' && (captureEntityName || captureEntityRole)) {
                         captureEntityValue = true;
                         captureEntityName = false;
                         captureEntityRole = false;
                         entityBuffer[entityBuffer.length - 1].type = 'labelled';
-                    } else if (char === ':') {
+                    } else if (char === ':' && captureEntityName) {
                         captureEntityValue = false;
                         captureEntityName = false;
                         captureEntityRole = true;
@@ -1050,10 +1050,6 @@ const parseAndHandleIntent = function (parsedContent, chunkSplitByLine) {
                         let nonAllowedRegexEntityInUtterance = (parsedContent.LUISJsonStructure.regex_entities || []).find(item => item.name == entity.entity);
                         if (nonAllowedRegexEntityInUtterance !== undefined) {
                             throw(new exception(retCode.errorCode.INVALID_INPUT, `Utterance "${utterance}" has invalid reference to regex entity "${nonAllowedRegexEntityInUtterance.name}". RegEx entities cannot be given an explicit labelled value.`));
-                        }
-                        let nonAllowedPatternAnyEntityInUtterance = (parsedContent.LUISJsonStructure.patternAnyEntities || []).find(item => item.name == entity.entity);
-                        if (nonAllowedPatternAnyEntityInUtterance !== undefined) {
-                            throw(new exception(retCode.errorCode.INVALID_INPUT, `Utterance "${utterance}" has invalid reference to Pattern.Any entity "${nonAllowedPatternAnyEntityInUtterance.name}". Pattern.Any entities cannot be given an explicit labelled value.`));
                         }
                         let nonAllowedPhrseListEntityInUtterance = (parsedContent.LUISJsonStructure.model_features || []).find(item => item.name == entity.entity);
                         if (nonAllowedPhrseListEntityInUtterance !== undefined) {

--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -948,6 +948,11 @@ const parseAndHandleIntent = function (parsedContent, chunkSplitByLine) {
                 // walk through the utterance and handle all entities
                 utterance.split('').forEach(char => {
                     if (char === '{') {
+                        // Handle cases where we are dealing with composites
+                        if (entityBuffer.length > 1) {
+                            // Nested composites are not supported. Throw.
+                            throw (new exception(retCode.errorCode.INVALID_INPUT, `[ERROR]: Utterance "${utterance}" has nested composite references. e.g. {a = {b = x}} is valid but {a = {b = {c = x}}} is invalid.`));
+                        }
                         entityBuffer.push({
                             startPos: utteranceWithoutEntityLabel.length,
                             entity: '',
@@ -974,6 +979,13 @@ const parseAndHandleIntent = function (parsedContent, chunkSplitByLine) {
                             }
                             
                         } else {
+                            if (entityBuffer.length > 1) {
+                                // add first entity's labelled value (if any to utterance)
+                                utteranceWithoutEntityLabel += entityBuffer[0].labelledValue.trimLeft();
+                                entityBuffer[0].labelledValue = "";
+                                // re-compute start position
+                                entityBuffer[entityBuffer.length - 1].startPos = utteranceWithoutEntityLabel.length;
+                            } 
                             utteranceWithoutEntityLabel += entityBuffer[entityBuffer.length - 1].labelledValue.trim();
                             entityBuffer[entityBuffer.length - 1].endPos = utteranceWithoutEntityLabel.length - 1;
                             entityBuffer[entityBuffer.length - 1].labelledValue = entityBuffer[entityBuffer.length - 1].labelledValue.trim();

--- a/packages/Ludown/test/ludown.roleTests.test.suite.js
+++ b/packages/Ludown/test/ludown.roleTests.test.suite.js
@@ -19,6 +19,31 @@ describe('Roles in LU files', function() {
             .catch(err => done(err));
     });
 
+    it('colon usage in utterance text outside of roles is parsed correctly', function (done) {
+        let fileContent = `# testIntent
+        - this is a : test intent {userName=vishwac}`;
+        parser.parseFile(fileContent, false, null) 
+            .then(res => {
+                assert.equal(res.LUISJsonStructure.entities[0].name, 'userName');
+                assert.equal(res.LUISJsonStructure.utterances.length, 1);
+                assert.equal(res.LUISJsonStructure.utterances[0].text, "this is a : test intent vishwac");
+                done();
+            })
+            .catch(err => done(err));
+    });
+
+    it('equal usage in utterance text outside of roles is parsed correctly', function (done) {
+        let fileContent = `# testIntent
+        - this is a = test intent {userName=vishwac}`;
+        parser.parseFile(fileContent, false, null) 
+            .then(res => {
+                assert.equal(res.LUISJsonStructure.entities[0].name, 'userName');
+                assert.equal(res.LUISJsonStructure.utterances.length, 1);
+                assert.equal(res.LUISJsonStructure.utterances[0].text, "this is a = test intent vishwac");
+                done();
+            })
+            .catch(err => done(err));
+    })
     it('Correctly parses roles with explict type definition in LU files', function(done) {
         let fileContent = `# getUserName
         - call me {name:userName}
@@ -115,18 +140,7 @@ describe('Roles in LU files', function() {
             .catch (err => done())
     }); 
 
-    it ('Pattern.Any entities cannot be explicitly labelled in utterances', function(done){
-        let testLU = `
-        # test1
-        - book a flight to {location}
-        
-        # testIntent
-        - book a flight to {location=redmond}`;
-
-        parser.parseFile(testLU, false, null) 
-            .then (res => done (`Test failed - ${JSON.stringify(res)}`))
-            .catch (err => done())
-    }); 
+    
 
     it ('RegEx entities cannot be explicitly labelled in utterances', function(done){
         let testLU = `
@@ -212,19 +226,7 @@ describe('Roles in LU files', function() {
             .catch (err => done ())
     })
 
-    it ('implicit pattern any entity type definition after adding it implicitly via a labelled value in an utterance throws correctly', function(done){
-        let testLU = `# test 2
-        - this is a {test}
-
-        # test
-        - this is a test of {test:fromTime = 7AM}
-        
-        `;
-
-        parser.parseFile(testLU, false, null)
-            .then (res => done(`Test failed - ${JSON.stringify(res)}`))
-            .catch (err => done ())
-    })
+    
 
     it ('explicit phrase list entity type definition after adding it implicitly via a labelled value in an utterance throws correctly', function(done){
         let testLU = `# test


### PR DESCRIPTION
- Fixes an issue introduced in 1.3.0 of ludown that breaks VA skills.
- Fix for #1129 

In order to support roles, I re-wrote the core parser that broke existing .lu files that had references to ':' and '=' outside of role definition/ labelled value assignment. This fixes the tokenizer walk on parser to accommodate for usage of ':' and '=' outside of role/ labelled value assignment. 

Also fixed issue reported in #1129.

- Added tests.
- Verified all existing tests pass. 