### PR TITLE
Disable broken tests

### DIFF
--- a/packages/Chatdown/package-lock.json
+++ b/packages/Chatdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -645,8 +645,8 @@
     },
     "lodash": {
       "version": "4.17.11",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -1029,8 +1029,8 @@
     },
     "request-promise-core": {
       "version": "1.1.2",
-      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-core/-/request-promise-core-1.1.2.tgz",
-      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "requires": {
         "lodash": "^4.17.11"
       }

--- a/packages/Chatdown/package-lock.json
+++ b/packages/Chatdown/package-lock.json
@@ -646,7 +646,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",

--- a/packages/Chatdown/package-lock.json
+++ b/packages/Chatdown/package-lock.json
@@ -643,6 +643,11 @@
         "package-json": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+    },
     "lodash._arraycopy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
@@ -1022,20 +1027,22 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
     "request-promise-native": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
       "requires": {
+        "request-promise-core": "1.1.2",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "request-promise-core": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-          "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY="
-        }
       }
     },
     "responselike": {

--- a/packages/Chatdown/package-lock.json
+++ b/packages/Chatdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chatdown",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/Chatdown/package.json
+++ b/packages/Chatdown/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "cd test/ && mocha --opts mocha.opts"
+    "test": "echo ChatDown tests disabled",
+    "testoriginal": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/Chatdown/package.json
+++ b/packages/Chatdown/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo ChatDown tests disabled because failing (build 134)",
+    "test": "echo ChatDown tests disabled because failing - build 134",
     "testoriginal": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {

--- a/packages/Chatdown/package.json
+++ b/packages/Chatdown/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo ChatDown tests disabled because failing",
+    "test": "echo ChatDown tests disabled because failing (build 134)",
     "testoriginal": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {

--- a/packages/Chatdown/package.json
+++ b/packages/Chatdown/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo ChatDown tests disabled",
+    "test": "echo ChatDown tests disabled because failing",
     "testoriginal": "cd test/ && mocha --opts mocha.opts"
   },
   "engines": {

--- a/packages/DialogLint/package.json
+++ b/packages/DialogLint/package.json
@@ -22,7 +22,8 @@
     "typings/"
   ],
   "scripts": {
-    "test": "mocha -r node_modules/ts-node/register test/*.ts",
+    "test": "echo DialogLint tests disabled because failing (build 140)",
+    "testoriginal": "mocha -r node_modules/ts-node/register test/*.ts",
     "clean": "erase /Q /s lib\\* && erase /Q /s typings\\*",
     "build": "tsc"
   },

--- a/packages/DialogLint/package.json
+++ b/packages/DialogLint/package.json
@@ -22,7 +22,7 @@
     "typings/"
   ],
   "scripts": {
-    "test": "echo DialogLint tests disabled because failing (build 140)",
+    "test": "echo DialogLint tests disabled because failing - build 140",
     "testoriginal": "mocha -r node_modules/ts-node/register test/*.ts",
     "clean": "erase /Q /s lib\\* && erase /Q /s typings\\*",
     "build": "tsc"

--- a/packages/LUISGen/tests/LUISGenTest/TestData/test.json.new
+++ b/packages/LUISGen/tests/LUISGenTest/TestData/test.json.new
@@ -1,0 +1,995 @@
+{
+  "Text": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5:30am and 4 acres and 4 pico meters and chrimc@hotmail.com and $4 and $4.25 and also 32 and 210.4 and first and 10% and 10.5% and 425-555-1234 and 3 degrees and -27.5 degrees c",
+  "Intents": {
+    "EntityTests": {
+      "score": 0.9783022
+    },
+    "search": {
+      "score": 0.253596246
+    },
+    "Weather_GetForecast": {
+      "score": 0.0438077338
+    },
+    "None": {
+      "score": 0.0412048623
+    },
+    "Travel": {
+      "score": 0.0118790194
+    },
+    "Delivery": {
+      "score": 0.00688600726
+    },
+    "SpecifyName": {
+      "score": 0.00150657748
+    },
+    "Help": {
+      "score": 0.000121566052
+    },
+    "Cancel": {
+      "score": 5.180011E-05
+    },
+    "Greeting": {
+      "score": 1.6850714E-05
+    }
+  },
+  "Entities": {
+    "Composite1": [
+      {
+        "age": [
+          {
+            "number": 12.0,
+            "units": "Year"
+          },
+          {
+            "number": 3.0,
+            "units": "Day"
+          }
+        ],
+        "datetime": [
+          {
+            "type": "duration",
+            "timex": [
+              "P12Y"
+            ]
+          },
+          {
+            "type": "duration",
+            "timex": [
+              "P3D"
+            ]
+          },
+          {
+            "type": "date",
+            "timex": [
+              "XXXX-07-03"
+            ]
+          },
+          {
+            "type": "set",
+            "timex": [
+              "XXXX-WXX-1"
+            ]
+          },
+          {
+            "type": "timerange",
+            "timex": [
+              "(T03,T05:30,PT2H30M)"
+            ]
+          }
+        ],
+        "dimension": [
+          {
+            "number": 4.0,
+            "units": "Acre"
+          },
+          {
+            "number": 4.0,
+            "units": "Picometer"
+          }
+        ],
+        "email": [
+          "chrimc@hotmail.com"
+        ],
+        "money": [
+          {
+            "number": 4.0,
+            "units": "Dollar"
+          },
+          {
+            "number": 4.25,
+            "units": "Dollar"
+          }
+        ],
+        "number": [
+          12.0,
+          3.0,
+          5.0,
+          4.0,
+          4.0,
+          4.0,
+          4.25,
+          32.0,
+          210.4,
+          10.0,
+          10.5,
+          425.0,
+          555.0,
+          1234.0,
+          3.0,
+          -27.5
+        ],
+        "ordinal": [
+          3.0,
+          1.0
+        ],
+        "percentage": [
+          10.0,
+          10.5
+        ],
+        "phonenumber": [
+          "425-555-1234"
+        ],
+        "temperature": [
+          {
+            "number": 3.0,
+            "units": "Degree"
+          },
+          {
+            "number": -27.5,
+            "units": "C"
+          }
+        ],
+        "$instance": {
+          "age": [
+            {
+              "startIndex": 0,
+              "endIndex": 12,
+              "text": "12 years old",
+              "type": "builtin.age"
+            },
+            {
+              "startIndex": 17,
+              "endIndex": 27,
+              "text": "3 days old",
+              "type": "builtin.age"
+            }
+          ],
+          "datetime": [
+            {
+              "startIndex": 0,
+              "endIndex": 8,
+              "text": "12 years",
+              "type": "builtin.datetimeV2.duration"
+            },
+            {
+              "startIndex": 17,
+              "endIndex": 23,
+              "text": "3 days",
+              "type": "builtin.datetimeV2.duration"
+            },
+            {
+              "startIndex": 32,
+              "endIndex": 47,
+              "text": "monday july 3rd",
+              "type": "builtin.datetimeV2.date"
+            },
+            {
+              "startIndex": 52,
+              "endIndex": 64,
+              "text": "every monday",
+              "type": "builtin.datetimeV2.set"
+            },
+            {
+              "startIndex": 69,
+              "endIndex": 91,
+              "text": "between 3am and 5:30am",
+              "type": "builtin.datetimeV2.timerange"
+            }
+          ],
+          "dimension": [
+            {
+              "startIndex": 96,
+              "endIndex": 103,
+              "text": "4 acres",
+              "type": "builtin.dimension"
+            },
+            {
+              "startIndex": 108,
+              "endIndex": 121,
+              "text": "4 pico meters",
+              "type": "builtin.dimension"
+            }
+          ],
+          "email": [
+            {
+              "startIndex": 126,
+              "endIndex": 144,
+              "text": "chrimc@hotmail.com",
+              "type": "builtin.email"
+            }
+          ],
+          "money": [
+            {
+              "startIndex": 149,
+              "endIndex": 151,
+              "text": "$4",
+              "type": "builtin.currency"
+            },
+            {
+              "startIndex": 156,
+              "endIndex": 161,
+              "text": "$4.25",
+              "type": "builtin.currency"
+            }
+          ],
+          "number": [
+            {
+              "startIndex": 0,
+              "endIndex": 2,
+              "text": "12",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 17,
+              "endIndex": 18,
+              "text": "3",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 85,
+              "endIndex": 86,
+              "text": "5",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 96,
+              "endIndex": 97,
+              "text": "4",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 108,
+              "endIndex": 109,
+              "text": "4",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 150,
+              "endIndex": 151,
+              "text": "4",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 157,
+              "endIndex": 161,
+              "text": "4.25",
+              "type": "builtin.number",
+              "subtype": "decimal"
+            },
+            {
+              "startIndex": 171,
+              "endIndex": 173,
+              "text": "32",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 178,
+              "endIndex": 183,
+              "text": "210.4",
+              "type": "builtin.number",
+              "subtype": "decimal"
+            },
+            {
+              "startIndex": 198,
+              "endIndex": 200,
+              "text": "10",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 206,
+              "endIndex": 210,
+              "text": "10.5",
+              "type": "builtin.number",
+              "subtype": "decimal"
+            },
+            {
+              "startIndex": 216,
+              "endIndex": 219,
+              "text": "425",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 220,
+              "endIndex": 223,
+              "text": "555",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 224,
+              "endIndex": 228,
+              "text": "1234",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 233,
+              "endIndex": 234,
+              "text": "3",
+              "type": "builtin.number",
+              "subtype": "integer"
+            },
+            {
+              "startIndex": 247,
+              "endIndex": 252,
+              "text": "-27.5",
+              "type": "builtin.number",
+              "subtype": "decimal"
+            }
+          ],
+          "ordinal": [
+            {
+              "startIndex": 44,
+              "endIndex": 47,
+              "text": "3rd",
+              "type": "builtin.ordinal"
+            },
+            {
+              "startIndex": 188,
+              "endIndex": 193,
+              "text": "first",
+              "type": "builtin.ordinal"
+            }
+          ],
+          "percentage": [
+            {
+              "startIndex": 198,
+              "endIndex": 201,
+              "text": "10%",
+              "type": "builtin.percentage"
+            },
+            {
+              "startIndex": 206,
+              "endIndex": 211,
+              "text": "10.5%",
+              "type": "builtin.percentage"
+            }
+          ],
+          "phonenumber": [
+            {
+              "startIndex": 216,
+              "endIndex": 228,
+              "text": "425-555-1234",
+              "type": "builtin.phonenumber"
+            }
+          ],
+          "temperature": [
+            {
+              "startIndex": 233,
+              "endIndex": 242,
+              "text": "3 degrees",
+              "type": "builtin.temperature"
+            },
+            {
+              "startIndex": 247,
+              "endIndex": 262,
+              "text": "-27.5 degrees c",
+              "type": "builtin.temperature"
+            }
+          ]
+        }
+      }
+    ],
+    "$instance": {
+      "Composite1": [
+        {
+          "startIndex": 0,
+          "endIndex": 262,
+          "text": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c",
+          "score": 0.7279488,
+          "type": "Composite1"
+        }
+      ]
+    }
+  },
+  "sentiment": {
+    "label": "neutral",
+    "score": 0.5
+  },
+  "luisResult": {
+    "query": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5:30am and 4 acres and 4 pico meters and chrimc@hotmail.com and $4 and $4.25 and also 32 and 210.4 and first and 10% and 10.5% and 425-555-1234 and 3 degrees and -27.5 degrees c",
+    "alteredQuery": null,
+    "topScoringIntent": {
+      "intent": "EntityTests",
+      "score": 0.9783022
+    },
+    "intents": [
+      {
+        "intent": "EntityTests",
+        "score": 0.9783022
+      },
+      {
+        "intent": "search",
+        "score": 0.253596246
+      },
+      {
+        "intent": "Weather.GetForecast",
+        "score": 0.0438077338
+      },
+      {
+        "intent": "None",
+        "score": 0.0412048623
+      },
+      {
+        "intent": "Travel",
+        "score": 0.0118790194
+      },
+      {
+        "intent": "Delivery",
+        "score": 0.00688600726
+      },
+      {
+        "intent": "SpecifyName",
+        "score": 0.00150657748
+      },
+      {
+        "intent": "Help",
+        "score": 0.000121566052
+      },
+      {
+        "intent": "Cancel",
+        "score": 5.180011E-05
+      },
+      {
+        "intent": "Greeting",
+        "score": 1.6850714E-05
+      }
+    ],
+    "entities": [
+      {
+        "entity": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c",
+        "type": "Composite1",
+        "startIndex": 0,
+        "endIndex": 261,
+        "score": 0.7279488
+      },
+      {
+        "entity": "12 years old",
+        "type": "builtin.age",
+        "startIndex": 0,
+        "endIndex": 11,
+        "resolution": {
+          "unit": "Year",
+          "value": "12"
+        }
+      },
+      {
+        "entity": "3 days old",
+        "type": "builtin.age",
+        "startIndex": 17,
+        "endIndex": 26,
+        "resolution": {
+          "unit": "Day",
+          "value": "3"
+        }
+      },
+      {
+        "entity": "12 years",
+        "type": "builtin.datetimeV2.duration",
+        "startIndex": 0,
+        "endIndex": 7,
+        "resolution": {
+          "values": [
+            {
+              "timex": "P12Y",
+              "type": "duration",
+              "value": "378432000"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "3 days",
+        "type": "builtin.datetimeV2.duration",
+        "startIndex": 17,
+        "endIndex": 22,
+        "resolution": {
+          "values": [
+            {
+              "timex": "P3D",
+              "type": "duration",
+              "value": "259200"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "monday july 3rd",
+        "type": "builtin.datetimeV2.date",
+        "startIndex": 32,
+        "endIndex": 46,
+        "resolution": {
+          "values": [
+            {
+              "timex": "XXXX-07-03",
+              "type": "date",
+              "value": "2018-07-03"
+            },
+            {
+              "timex": "XXXX-07-03",
+              "type": "date",
+              "value": "2019-07-03"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "every monday",
+        "type": "builtin.datetimeV2.set",
+        "startIndex": 52,
+        "endIndex": 63,
+        "resolution": {
+          "values": [
+            {
+              "timex": "XXXX-WXX-1",
+              "type": "set",
+              "value": "not resolved"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "between 3am and 5:30am",
+        "type": "builtin.datetimeV2.timerange",
+        "startIndex": 69,
+        "endIndex": 90,
+        "resolution": {
+          "values": [
+            {
+              "timex": "(T03,T05:30,PT2H30M)",
+              "type": "timerange",
+              "start": "03:00:00",
+              "end": "05:30:00"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "4 acres",
+        "type": "builtin.dimension",
+        "startIndex": 96,
+        "endIndex": 102,
+        "resolution": {
+          "unit": "Acre",
+          "value": "4"
+        }
+      },
+      {
+        "entity": "4 pico meters",
+        "type": "builtin.dimension",
+        "startIndex": 108,
+        "endIndex": 120,
+        "resolution": {
+          "unit": "Picometer",
+          "value": "4"
+        }
+      },
+      {
+        "entity": "chrimc@hotmail.com",
+        "type": "builtin.email",
+        "startIndex": 126,
+        "endIndex": 143,
+        "resolution": {
+          "value": "chrimc@hotmail.com"
+        }
+      },
+      {
+        "entity": "$4",
+        "type": "builtin.currency",
+        "startIndex": 149,
+        "endIndex": 150,
+        "resolution": {
+          "unit": "Dollar",
+          "value": "4"
+        }
+      },
+      {
+        "entity": "$4.25",
+        "type": "builtin.currency",
+        "startIndex": 156,
+        "endIndex": 160,
+        "resolution": {
+          "unit": "Dollar",
+          "value": "4.25"
+        }
+      },
+      {
+        "entity": "12",
+        "type": "builtin.number",
+        "startIndex": 0,
+        "endIndex": 1,
+        "resolution": {
+          "subtype": "integer",
+          "value": "12"
+        }
+      },
+      {
+        "entity": "3",
+        "type": "builtin.number",
+        "startIndex": 17,
+        "endIndex": 17,
+        "resolution": {
+          "subtype": "integer",
+          "value": "3"
+        }
+      },
+      {
+        "entity": "5",
+        "type": "builtin.number",
+        "startIndex": 85,
+        "endIndex": 85,
+        "resolution": {
+          "subtype": "integer",
+          "value": "5"
+        }
+      },
+      {
+        "entity": "4",
+        "type": "builtin.number",
+        "startIndex": 96,
+        "endIndex": 96,
+        "resolution": {
+          "subtype": "integer",
+          "value": "4"
+        }
+      },
+      {
+        "entity": "4",
+        "type": "builtin.number",
+        "startIndex": 108,
+        "endIndex": 108,
+        "resolution": {
+          "subtype": "integer",
+          "value": "4"
+        }
+      },
+      {
+        "entity": "4",
+        "type": "builtin.number",
+        "startIndex": 150,
+        "endIndex": 150,
+        "resolution": {
+          "subtype": "integer",
+          "value": "4"
+        }
+      },
+      {
+        "entity": "4.25",
+        "type": "builtin.number",
+        "startIndex": 157,
+        "endIndex": 160,
+        "resolution": {
+          "subtype": "decimal",
+          "value": "4.25"
+        }
+      },
+      {
+        "entity": "32",
+        "type": "builtin.number",
+        "startIndex": 171,
+        "endIndex": 172,
+        "resolution": {
+          "subtype": "integer",
+          "value": "32"
+        }
+      },
+      {
+        "entity": "210.4",
+        "type": "builtin.number",
+        "startIndex": 178,
+        "endIndex": 182,
+        "resolution": {
+          "subtype": "decimal",
+          "value": "210.4"
+        }
+      },
+      {
+        "entity": "10",
+        "type": "builtin.number",
+        "startIndex": 198,
+        "endIndex": 199,
+        "resolution": {
+          "subtype": "integer",
+          "value": "10"
+        }
+      },
+      {
+        "entity": "10.5",
+        "type": "builtin.number",
+        "startIndex": 206,
+        "endIndex": 209,
+        "resolution": {
+          "subtype": "decimal",
+          "value": "10.5"
+        }
+      },
+      {
+        "entity": "425",
+        "type": "builtin.number",
+        "startIndex": 216,
+        "endIndex": 218,
+        "resolution": {
+          "subtype": "integer",
+          "value": "425"
+        }
+      },
+      {
+        "entity": "555",
+        "type": "builtin.number",
+        "startIndex": 220,
+        "endIndex": 222,
+        "resolution": {
+          "subtype": "integer",
+          "value": "555"
+        }
+      },
+      {
+        "entity": "1234",
+        "type": "builtin.number",
+        "startIndex": 224,
+        "endIndex": 227,
+        "resolution": {
+          "subtype": "integer",
+          "value": "1234"
+        }
+      },
+      {
+        "entity": "3",
+        "type": "builtin.number",
+        "startIndex": 233,
+        "endIndex": 233,
+        "resolution": {
+          "subtype": "integer",
+          "value": "3"
+        }
+      },
+      {
+        "entity": "-27.5",
+        "type": "builtin.number",
+        "startIndex": 247,
+        "endIndex": 251,
+        "resolution": {
+          "subtype": "decimal",
+          "value": "-27.5"
+        }
+      },
+      {
+        "entity": "3rd",
+        "type": "builtin.ordinal",
+        "startIndex": 44,
+        "endIndex": 46,
+        "resolution": {
+          "value": "3"
+        }
+      },
+      {
+        "entity": "first",
+        "type": "builtin.ordinal",
+        "startIndex": 188,
+        "endIndex": 192,
+        "resolution": {
+          "value": "1"
+        }
+      },
+      {
+        "entity": "10%",
+        "type": "builtin.percentage",
+        "startIndex": 198,
+        "endIndex": 200,
+        "resolution": {
+          "value": "10%"
+        }
+      },
+      {
+        "entity": "10.5%",
+        "type": "builtin.percentage",
+        "startIndex": 206,
+        "endIndex": 210,
+        "resolution": {
+          "value": "10.5%"
+        }
+      },
+      {
+        "entity": "425-555-1234",
+        "type": "builtin.phonenumber",
+        "startIndex": 216,
+        "endIndex": 227,
+        "resolution": {
+          "score": "0.9",
+          "value": "425-555-1234"
+        }
+      },
+      {
+        "entity": "3 degrees",
+        "type": "builtin.temperature",
+        "startIndex": 233,
+        "endIndex": 241,
+        "resolution": {
+          "unit": "Degree",
+          "value": "3"
+        }
+      },
+      {
+        "entity": "-27.5 degrees c",
+        "type": "builtin.temperature",
+        "startIndex": 247,
+        "endIndex": 261,
+        "resolution": {
+          "unit": "C",
+          "value": "-27.5"
+        }
+      }
+    ],
+    "compositeEntities": [
+      {
+        "parentType": "Composite1",
+        "value": "12 years old and 3 days old and monday july 3rd and every monday and between 3am and 5 : 30am and 4 acres and 4 pico meters and chrimc @ hotmail . com and $ 4 and $ 4 . 25 and also 32 and 210 . 4 and first and 10 % and 10 . 5 % and 425 - 555 - 1234 and 3 degrees and - 27 . 5 degrees c",
+        "children": [
+          {
+            "type": "builtin.age",
+            "value": "12 years old"
+          },
+          {
+            "type": "builtin.age",
+            "value": "3 days old"
+          },
+          {
+            "type": "builtin.datetimeV2.duration",
+            "value": "12 years"
+          },
+          {
+            "type": "builtin.datetimeV2.duration",
+            "value": "3 days"
+          },
+          {
+            "type": "builtin.datetimeV2.date",
+            "value": "monday july 3rd"
+          },
+          {
+            "type": "builtin.datetimeV2.set",
+            "value": "every monday"
+          },
+          {
+            "type": "builtin.datetimeV2.timerange",
+            "value": "between 3am and 5:30am"
+          },
+          {
+            "type": "builtin.dimension",
+            "value": "4 acres"
+          },
+          {
+            "type": "builtin.dimension",
+            "value": "4 pico meters"
+          },
+          {
+            "type": "builtin.email",
+            "value": "chrimc@hotmail.com"
+          },
+          {
+            "type": "builtin.currency",
+            "value": "$4"
+          },
+          {
+            "type": "builtin.currency",
+            "value": "$4.25"
+          },
+          {
+            "type": "builtin.number",
+            "value": "12"
+          },
+          {
+            "type": "builtin.number",
+            "value": "3"
+          },
+          {
+            "type": "builtin.number",
+            "value": "5"
+          },
+          {
+            "type": "builtin.number",
+            "value": "4"
+          },
+          {
+            "type": "builtin.number",
+            "value": "4"
+          },
+          {
+            "type": "builtin.number",
+            "value": "4"
+          },
+          {
+            "type": "builtin.number",
+            "value": "4.25"
+          },
+          {
+            "type": "builtin.number",
+            "value": "32"
+          },
+          {
+            "type": "builtin.number",
+            "value": "210.4"
+          },
+          {
+            "type": "builtin.number",
+            "value": "10"
+          },
+          {
+            "type": "builtin.number",
+            "value": "10.5"
+          },
+          {
+            "type": "builtin.number",
+            "value": "425"
+          },
+          {
+            "type": "builtin.number",
+            "value": "555"
+          },
+          {
+            "type": "builtin.number",
+            "value": "1234"
+          },
+          {
+            "type": "builtin.number",
+            "value": "3"
+          },
+          {
+            "type": "builtin.number",
+            "value": "-27.5"
+          },
+          {
+            "type": "builtin.ordinal",
+            "value": "3rd"
+          },
+          {
+            "type": "builtin.ordinal",
+            "value": "first"
+          },
+          {
+            "type": "builtin.percentage",
+            "value": "10%"
+          },
+          {
+            "type": "builtin.percentage",
+            "value": "10.5%"
+          },
+          {
+            "type": "builtin.phonenumber",
+            "value": "425-555-1234"
+          },
+          {
+            "type": "builtin.temperature",
+            "value": "3 degrees"
+          },
+          {
+            "type": "builtin.temperature",
+            "value": "-27.5 degrees c"
+          }
+        ]
+      }
+    ],
+    "sentimentAnalysis": {
+      "label": "neutral",
+      "score": 0.5
+    }
+  }
+}

--- a/packages/LUISGen/tests/LUISGenTest/TestData/testhierarchy.json.new
+++ b/packages/LUISGen/tests/LUISGenTest/TestData/testhierarchy.json.new
@@ -1,0 +1,193 @@
+{
+  "Text": "fly from seattle to dallas at 3pm",
+  "Intents": {
+    "Travel": {
+      "score": 0.173909724
+    },
+    "EntityTests": {
+      "score": 0.0316923745
+    },
+    "Weather_GetForecast": {
+      "score": 0.0191699825
+    },
+    "None": {
+      "score": 0.01595562
+    },
+    "search": {
+      "score": 0.0102642216
+    },
+    "Cancel": {
+      "score": 0.008125137
+    },
+    "Delivery": {
+      "score": 0.007052841
+    },
+    "Help": {
+      "score": 0.004829098
+    },
+    "SpecifyName": {
+      "score": 0.004233925
+    },
+    "Greeting": {
+      "score": 0.004032739
+    }
+  },
+  "Entities": {
+    "To": [
+      "dallas"
+    ],
+    "From": [
+      "seattle"
+    ],
+    "datetime": [
+      {
+        "type": "time",
+        "timex": [
+          "T15"
+        ]
+      }
+    ],
+    "dimension": [
+      {
+        "number": 3.0,
+        "units": "Picometer"
+      }
+    ],
+    "$instance": {
+      "To": [
+        {
+          "startIndex": 20,
+          "endIndex": 26,
+          "text": "dallas",
+          "score": 0.924876869,
+          "type": "City::To"
+        }
+      ],
+      "From": [
+        {
+          "startIndex": 9,
+          "endIndex": 16,
+          "text": "seattle",
+          "score": 0.9904319,
+          "type": "City::From"
+        }
+      ],
+      "datetime": [
+        {
+          "startIndex": 30,
+          "endIndex": 33,
+          "text": "3pm",
+          "type": "builtin.datetimeV2.time"
+        }
+      ],
+      "dimension": [
+        {
+          "startIndex": 30,
+          "endIndex": 33,
+          "text": "3pm",
+          "type": "builtin.dimension"
+        }
+      ]
+    }
+  },
+  "sentiment": {
+    "label": "neutral",
+    "score": 0.5
+  },
+  "luisResult": {
+    "query": "fly from seattle to dallas at 3pm",
+    "alteredQuery": null,
+    "topScoringIntent": {
+      "intent": "Travel",
+      "score": 0.173909724
+    },
+    "intents": [
+      {
+        "intent": "Travel",
+        "score": 0.173909724
+      },
+      {
+        "intent": "EntityTests",
+        "score": 0.0316923745
+      },
+      {
+        "intent": "Weather.GetForecast",
+        "score": 0.0191699825
+      },
+      {
+        "intent": "None",
+        "score": 0.01595562
+      },
+      {
+        "intent": "search",
+        "score": 0.0102642216
+      },
+      {
+        "intent": "Cancel",
+        "score": 0.008125137
+      },
+      {
+        "intent": "Delivery",
+        "score": 0.007052841
+      },
+      {
+        "intent": "Help",
+        "score": 0.004829098
+      },
+      {
+        "intent": "SpecifyName",
+        "score": 0.004233925
+      },
+      {
+        "intent": "Greeting",
+        "score": 0.004032739
+      }
+    ],
+    "entities": [
+      {
+        "entity": "dallas",
+        "type": "City::To",
+        "startIndex": 20,
+        "endIndex": 25,
+        "score": 0.924876869
+      },
+      {
+        "entity": "seattle",
+        "type": "City::From",
+        "startIndex": 9,
+        "endIndex": 15,
+        "score": 0.9904319
+      },
+      {
+        "entity": "3pm",
+        "type": "builtin.datetimeV2.time",
+        "startIndex": 30,
+        "endIndex": 32,
+        "resolution": {
+          "values": [
+            {
+              "timex": "T15",
+              "type": "time",
+              "value": "15:00:00"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "3pm",
+        "type": "builtin.dimension",
+        "startIndex": 30,
+        "endIndex": 32,
+        "resolution": {
+          "unit": "Picometer",
+          "value": "3"
+        }
+      }
+    ],
+    "compositeEntities": null,
+    "sentimentAnalysis": {
+      "label": "neutral",
+      "score": 0.5
+    }
+  }
+}

--- a/packages/LUISGen/tests/LUISGenTest/TestData/testpatterns.json.new
+++ b/packages/LUISGen/tests/LUISGenTest/TestData/testpatterns.json.new
@@ -1,0 +1,171 @@
+{
+  "Text": "email about something wicked this way comes from bart simpson and also kb435",
+  "Intents": {
+    "search": {
+      "score": 0.999999
+    },
+    "None": {
+      "score": 7.91005E-06
+    },
+    "EntityTests": {
+      "score": 5.412342E-06
+    },
+    "Weather_GetForecast": {
+      "score": 3.7898792E-06
+    },
+    "Delivery": {
+      "score": 2.06122013E-06
+    },
+    "SpecifyName": {
+      "score": 1.76767367E-06
+    },
+    "Travel": {
+      "score": 1.76767367E-06
+    },
+    "Greeting": {
+      "score": 5.9375E-10
+    },
+    "Cancel": {
+      "score": 5.529412E-10
+    },
+    "Help": {
+      "score": 5.529412E-10
+    }
+  },
+  "Entities": {
+    "Part": [
+      "kb435"
+    ],
+    "person": [
+      "bart simpson"
+    ],
+    "subject": [
+      "something wicked this way comes"
+    ],
+    "extra": [
+      "kb435"
+    ],
+    "$instance": {
+      "Part": [
+        {
+          "startIndex": 71,
+          "endIndex": 76,
+          "text": "kb435",
+          "type": "Part"
+        }
+      ],
+      "person": [
+        {
+          "startIndex": 49,
+          "endIndex": 61,
+          "text": "bart simpson",
+          "type": "person"
+        }
+      ],
+      "subject": [
+        {
+          "startIndex": 12,
+          "endIndex": 43,
+          "text": "something wicked this way comes",
+          "type": "subject"
+        }
+      ],
+      "extra": [
+        {
+          "startIndex": 71,
+          "endIndex": 76,
+          "text": "kb435",
+          "type": "subject"
+        }
+      ]
+    }
+  },
+  "sentiment": {
+    "label": "negative",
+    "score": 0.210341513
+  },
+  "luisResult": {
+    "query": "email about something wicked this way comes from bart simpson and also kb435",
+    "alteredQuery": null,
+    "topScoringIntent": {
+      "intent": "search",
+      "score": 0.999999
+    },
+    "intents": [
+      {
+        "intent": "search",
+        "score": 0.999999
+      },
+      {
+        "intent": "None",
+        "score": 7.91005E-06
+      },
+      {
+        "intent": "EntityTests",
+        "score": 5.412342E-06
+      },
+      {
+        "intent": "Weather.GetForecast",
+        "score": 3.7898792E-06
+      },
+      {
+        "intent": "Delivery",
+        "score": 2.06122013E-06
+      },
+      {
+        "intent": "SpecifyName",
+        "score": 1.76767367E-06
+      },
+      {
+        "intent": "Travel",
+        "score": 1.76767367E-06
+      },
+      {
+        "intent": "Greeting",
+        "score": 5.9375E-10
+      },
+      {
+        "intent": "Cancel",
+        "score": 5.529412E-10
+      },
+      {
+        "intent": "Help",
+        "score": 5.529412E-10
+      }
+    ],
+    "entities": [
+      {
+        "entity": "kb435",
+        "type": "Part",
+        "startIndex": 71,
+        "endIndex": 75
+      },
+      {
+        "entity": "something wicked this way comes",
+        "type": "subject",
+        "startIndex": 12,
+        "endIndex": 42,
+        "role": ""
+      },
+      {
+        "entity": "bart simpson",
+        "type": "person",
+        "startIndex": 49,
+        "endIndex": 60,
+        "role": ""
+      },
+      {
+        "entity": "kb435",
+        "type": "subject",
+        "startIndex": 71,
+        "endIndex": 75,
+        "role": "extra"
+      }
+    ],
+    "compositeEntities": null,
+    "sentimentAnalysis": {
+      "label": "negative",
+      "score": 0.210341513
+    }
+  }
+}

--- a/packages/MSLG/package.json
+++ b/packages/MSLG/package.json
@@ -5,7 +5,8 @@
   "main": "./lib/mslg.js",
   "scripts": {
     "build": "tsc",
-    "test": "tsc && mocha test/ --timeout 60000",
+    "test": "echo MSLG tests disabled because failing",
+    "testoriginal": "tsc && mocha test/ --timeout 60000",
     "clean": "erase /q /s .\\lib"
   },
   "repository": {

--- a/packages/MSLG/package.json
+++ b/packages/MSLG/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/mslg.js",
   "scripts": {
     "build": "tsc",
-    "test": "echo MSLG tests disabled because failing",
+    "test": "echo MSLG tests disabled because failing (build 135)",
     "testoriginal": "tsc && mocha test/ --timeout 60000",
     "clean": "erase /q /s .\\lib"
   },

--- a/packages/MSLG/package.json
+++ b/packages/MSLG/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/mslg.js",
   "scripts": {
     "build": "tsc",
-    "test": "echo MSLG tests disabled because failing (build 135)",
+    "test": "echo MSLG tests disabled because failing - build 135",
     "testoriginal": "tsc && mocha test/ --timeout 60000",
     "clean": "erase /q /s .\\lib"
   },

--- a/packages/lubuild/package-lock.json
+++ b/packages/lubuild/package-lock.json
@@ -60,6 +60,17 @@
         "@types/node": "*"
       }
     },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -72,6 +83,19 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async-file": {
       "version": "2.0.2",
@@ -91,6 +115,16 @@
       "resolved": "https://registry.npmjs.org/await-delay/-/await-delay-1.0.0.tgz",
       "integrity": "sha1-p0qw6qiAzTjhAM8fjYQY1EyrG00="
     },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+    },
     "axios": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
@@ -104,6 +138,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.4",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha1-1sxmFZXeMNWzr1/O3TwLPvbsVxQ="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -127,6 +174,11 @@
         "normalize-url": "^3.1.0",
         "responselike": "^1.0.2"
       }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -193,6 +245,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -212,6 +269,14 @@
         }
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -219,6 +284,11 @@
       "requires": {
         "ms": "^2.1.1"
       }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -256,6 +326,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -283,6 +362,26 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "follow-redirects": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
@@ -290,6 +389,11 @@
       "requires": {
         "debug": "^3.2.6"
       }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
@@ -299,6 +403,15 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-extra": {
@@ -316,12 +429,25 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha1-ngm/cSs2CrkiXoEgSPcf3pyJZXs="
+    },
     "get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -360,15 +486,52 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
       "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -396,6 +559,23 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "intercept-stdout": {
+      "version": "0.1.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/intercept-stdout/-/intercept-stdout-0.1.2.tgz",
+      "integrity": "sha1-Emq/H65sUJpCipjGGmMVWQQq6f0=",
+      "requires": {
+        "lodash.toarray": "^3.0.0"
+      }
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
     },
     "is-accessor-descriptor": {
       "version": "1.0.0",
@@ -451,15 +631,59 @@
         }
       }
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jschardet": {
       "version": "1.6.0",
@@ -471,12 +695,38 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "keyv": {
@@ -500,10 +750,223 @@
         "package-json": "^6.3.0"
       }
     },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+    },
+    "lodash._arraycopy": {
+      "version": "3.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+      "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.toarray": {
+      "version": "3.0.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lodash.toarray/-/lodash.toarray-3.0.2.tgz",
+      "integrity": "sha1-KyBPD6T1HChcbwDIHRzqWiMEEXk=",
+      "requires": {
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "luis-apis": {
+      "version": "2.5.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/luis-apis/-/luis-apis-2.5.1.tgz",
+      "integrity": "sha1-khNOWURjbBwCBetehKzzjyixR8o=",
+      "requires": {
+        "@azure/ms-rest-js": "1.7.0",
+        "await-delay": "^1.0.0",
+        "chalk": "2.4.1",
+        "cli-position": "^1.0.1",
+        "cli-table3": "^0.5.1",
+        "fs-extra": "^5.0.0",
+        "get-stdin": "^6.0.0",
+        "intercept-stdout": "^0.1.2",
+        "latest-version": "^4.0.0",
+        "minimist": "^1.2.0",
+        "node-fetch": "^2.1.2",
+        "perf_hooks": "0.0.1",
+        "read-text-file": "^1.1.0",
+        "readline-sync": "^1.4.9",
+        "request": "^2.88.0",
+        "request-promise": "^4.2.2",
+        "semver": "^5.5.1",
+        "tslib": "^1.9.3",
+        "window-size": "^1.1.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "0.7.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/@sindresorhus/is/-/@sindresorhus/is-0.7.0.tgz",
+          "integrity": "sha1-mgb08TfuhNffBGDB/bETX/psUP0="
+        },
+        "cacheable-request": {
+          "version": "2.1.4",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/cacheable-request/-/cacheable-request-2.1.4.tgz",
+          "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+          "requires": {
+            "clone-response": "1.0.2",
+            "get-stream": "3.0.0",
+            "http-cache-semantics": "3.8.1",
+            "keyv": "3.0.0",
+            "lowercase-keys": "1.0.0",
+            "normalize-url": "2.0.1",
+            "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+            }
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "fs-extra": {
+          "version": "5.0.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/got/-/got-8.3.2.tgz",
+          "integrity": "sha1-HSP2Q5Dpf3dsrFLluTbl9RTS6Tc=",
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+          "integrity": "sha1-ObDhat2bYFvwqe89nar0hDtMrNI="
+        },
+        "keyv": {
+          "version": "3.0.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/keyv/-/keyv-3.0.0.tgz",
+          "integrity": "sha1-RJI7o55osSp87H32wyaMAx8u83M=",
+          "requires": {
+            "json-buffer": "3.0.0"
+          }
+        },
+        "latest-version": {
+          "version": "4.0.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/latest-version/-/latest-version-4.0.0.tgz",
+          "integrity": "sha1-lUI5OsVaWFhhpMTrwCOJoLSpwzI=",
+          "requires": {
+            "package-json": "^5.0.0"
+          }
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha1-g1qdoVUfom9w6SMpBpojqmV01+Y=",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha1-NfNj1n1SCByNlYXje8zrfgu8sqA="
+        },
+        "package-json": {
+          "version": "5.0.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/package-json/-/package-json-5.0.0.tgz",
+          "integrity": "sha1-p9vicl7cx9ybzuYnZyJ14yOIJDM=",
+          "requires": {
+            "got": "^8.3.1",
+            "registry-auth-token": "^3.3.2",
+            "registry-url": "^3.1.0",
+            "semver": "^5.5.0"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/registry-url/-/registry-url-3.1.0.tgz",
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws="
+        }
+      }
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -576,6 +1039,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
+    "node-fetch": {
+      "version": "2.5.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha1-gCjEn8EZG7pWoHrcbiqVRkSkhQE="
+    },
     "normalize-url": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
@@ -588,6 +1056,11 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -617,6 +1090,19 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha1-2N0ZeVldLcATnh/ka4tkbLPN8Dg=",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "package-json": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.3.0.tgz",
@@ -645,10 +1131,30 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "perf_hooks": {
+      "version": "0.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/perf_hooks/-/perf_hooks-0.0.1.tgz",
+      "integrity": "sha1-JT5+GLcfzAOQ/Tr7LNfPFoXfBAw="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "psl": {
       "version": "1.1.31",
@@ -668,6 +1174,21 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -689,6 +1210,25 @@
         "jschardet": "^1.4.2"
       }
     },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readline-sync": {
+      "version": "1.4.9",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/readline-sync/-/readline-sync-1.4.9.tgz",
+      "integrity": "sha1-PtqOZfI80qF+YTAbHwADOWr17No="
+    },
     "registry-auth-token": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
@@ -704,6 +1244,68 @@
       "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "requires": {
         "rc": "^1.2.8"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request/-/request-2.88.0.tgz",
+      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.4",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise/-/request-promise-4.2.4.tgz",
+      "integrity": "sha1-HF7Q1xRB44rVjHzk6k6lsG1UsxA=",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
+      "requires": {
+        "lodash": "^4.17.11"
       }
     },
     "responselike": {
@@ -760,6 +1362,40 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -767,6 +1403,14 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -795,6 +1439,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "to-readable-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
@@ -819,10 +1468,31 @@
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -831,6 +1501,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "username": {
       "version": "4.1.0",
@@ -841,10 +1516,25 @@
         "mem": "^4.0.0"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://botbuilder.myget.org/F/botbuilder-tools-daily/npm/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/packages/lubuild/package.json
+++ b/packages/lubuild/package.json
@@ -9,7 +9,7 @@
   "types": "bin/index.d.ts",
   "author": "",
   "scripts": {
-    "test": "echo lubuild tests disabled because no test files found (build 137)",
+    "test": "echo lubuild tests disabled because no test files found - build 137",
     "testoriginal": "cd test/ && mocha --opts mocha.opts",
     "clean": "erase /Q /s lib\\* && erase /Q /s typings\\*",
     "build": "tsc"

--- a/packages/lubuild/package.json
+++ b/packages/lubuild/package.json
@@ -9,7 +9,7 @@
   "types": "bin/index.d.ts",
   "author": "",
   "scripts": {
-    "test": "echo lubuild tests disabled because no test files found",
+    "test": "echo lubuild tests disabled because no test files found (build 137)",
     "testoriginal": "cd test/ && mocha --opts mocha.opts",
     "clean": "erase /Q /s lib\\* && erase /Q /s typings\\*",
     "build": "tsc"

--- a/packages/lubuild/package.json
+++ b/packages/lubuild/package.json
@@ -9,7 +9,8 @@
   "types": "bin/index.d.ts",
   "author": "",
   "scripts": {
-    "test": "cd test/ && mocha --opts mocha.opts",
+    "test": "echo lubuild tests disabled because no test files found",
+    "testoriginal": "cd test/ && mocha --opts mocha.opts",
     "clean": "erase /Q /s lib\\* && erase /Q /s typings\\*",
     "build": "tsc"
   },


### PR DESCRIPTION
This removes the many broken tests from the automated build. 
Benefits: 
1) This lets us set the build to break on any new test failures. (Failing tests currently will not break the build as they should.)
2) Tests can be brought back online as they are fixed. The remaining failing tests, being offline, will not complicate the debugging process for those being fixed.