### PR TITLE
Fix notation description for QnA in LUDown

### DIFF
--- a/packages/Ludown/docs/lu-file-format.md
+++ b/packages/Ludown/docs/lu-file-format.md
@@ -280,10 +280,12 @@ See this [example](..\examples\patterns.lu) for more details.
 ## Question and Answer pairs
 .lu file (and the parser) supports question and answer definitions as well. You can this notation to describe them:
 
-\# ? Question
-\[list of question variations]
 ```markdown
-	Answer
+# ? Question
+    [list of question variations]
+    ```markdown
+    Answer
+    ```
 ```
 
 Here's an example of question and answer definitions. The LUDown tool will automatically separate question and answers into a qnamaker JSON file that you can then use to create your new [QnaMaker.ai](http://qnamaker.ai) knowledge base article.


### PR DESCRIPTION
The description for QnA notation should be wrapped in a markdown block. The content needed to be indented for proper scoping of the inner markdown block.

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->

  - Fixes description for LUDown QnA notation