### PR TITLE
[Ludown] Fix converting regex entities containing a slash followed by a colon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,3 +308,6 @@ packages/lubuild/bin/**
 packages/lubuild/lib/**
 packages/lubuild/typings/**
 
+# Eclipse IDE
+.project
+.settings/

--- a/packages/Ludown/lib/helpers.js
+++ b/packages/Ludown/lib/helpers.js
@@ -266,7 +266,43 @@ const helpers = {
             returnValue.roles = parsedRoleDefinition.replace('[', '').replace(']', '').split(RolesSplitRegEx).map(item => item.trim());
         }
         return returnValue;
-    }
+    },
+
+    /**
+     * Custom implementation of the String.split() function that does not drop parts of the string if a limit is used.
+     * If a string can be split into more substrings than the provided limit,
+     * the left-over text is returned as part of the last array element.
+     * @param {String} string The string to split.
+     * @param {String} separator The separator string to split on.
+     * @param {Number} limit The maximum number of substrings to return.
+     */
+    split: function (string, separator, limit) {
+        const parts = [];
+        let i = 0;
+        if (separator.length === 0) {
+            while (i < string.length && (limit === undefined || parts.length < limit)) {
+                parts.push(string.substring(i, i + 1));
+                ++i;
+            }
+            if (i < string.length && parts.length !== 0) {
+                parts[parts.length - 1] += string.substring(i);
+            }
+        } else {
+            let found;
+            while (i < string.length
+                    && (limit === undefined || parts.length < limit)
+                    && (found = string.indexOf(separator, i)) >= 0) {
+                parts.push(string.substring(i, found));
+                i = found + separator.length;
+            }
+            if (limit === undefined || parts.length < limit) {
+                parts.push(string.substring(i));
+            } else if (parts.length !== 0) {
+                parts[parts.length - 1] += string.substring(i - separator.length);
+            }
+        }
+        return parts;
+    },
 };
 
 /**

--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -289,7 +289,7 @@ const parseFileContentsModule = {
                     } else {
                         // verify that the pattern is the same
                         if (entityExistsInFinal.regexPattern !== regexEntity.regexPattern) {
-                            throw (new exception(retCode.errorCode.INVALID_REGEX_ENTITY, `[ERROR]: RegEx entity : ${regExEntity.name} has inconsistent pattern definitions. \n 1. ${regexEntity.regexPattern} \n 2. ${entityExistsInFinal.regexPattern}`));
+                            throw (new exception(retCode.errorCode.INVALID_REGEX_ENTITY, `[ERROR]: RegEx entity : ${regexEntity.name} has inconsistent pattern definitions. \n 1. ${regexEntity.regexPattern} \n 2. ${entityExistsInFinal.regexPattern}`));
                         }
                         // merge roles
                         if (entityExistsInFinal.roles.length > 0) {
@@ -528,7 +528,7 @@ const mergeResults_closedlists = function (blob, finalCollection, type) {
  */
 const parseAndHandleEntity = function (parsedContent, chunkSplitByLine, locale, log) {
     // we have an entity definition
-    let entityDef = chunkSplitByLine[0].replace(PARSERCONSTS.ENTITY, '').split(':');
+    let entityDef = helpers.split(chunkSplitByLine[0].replace(PARSERCONSTS.ENTITY, ''), ':', 2);
     let entityName = entityDef[0].trim();
     let entityType = entityDef[1].trim();
     // call helper to get roles
@@ -593,7 +593,7 @@ const parseAndHandleEntity = function (parsedContent, chunkSplitByLine, locale, 
             }
             // handle regex entity 
             let regex = entityType.slice(1).slice(0, entityType.length - 2);
-            if (regex === '') throw (new exception(retCode.errorCode.INVALID_REGEX_ENTITY, `[ERROR]: RegEx entity: ${regExEntity.name} has empty regex pattern defined.`));
+            if (regex === '') throw (new exception(retCode.errorCode.INVALID_REGEX_ENTITY, `[ERROR]: RegEx entity: ${entityName} has empty regex pattern defined.`));
             // add this as a regex entity if it does not exist
             let regExEntity = (parsedContent.LUISJsonStructure.regex_entities || []).find(item => item.name == entityName);
             if (regExEntity === undefined) {

--- a/packages/Ludown/test/ludown.helpers.test.suite.js
+++ b/packages/Ludown/test/ludown.helpers.test.suite.js
@@ -206,4 +206,75 @@ describe('With helper functions', function() {
             done(new Error('Test failed: splitFileBySections invalid entity definition!'));
         }
     });
+
+    it('split should not drop left-over substring if limit is less than possible parts', function(done){
+        const runTest = function (string, separator, limit, expectedParts) {
+            const inputs = `String: ${JSON.stringify(string)} Separator: ${JSON.stringify(separator)} Limit: ${limit}`;
+            const actualParts = helpers.split(string, separator, limit);
+            assert.deepEqual(actualParts, expectedParts,
+                    `${inputs} Expected: ${JSON.stringify(expectedParts)} Actual: ${JSON.stringify(actualParts)}`);
+            for (const prop in actualParts) {
+                assert((typeof prop) === 'number' || !isNaN(prop), `${inputs} Expected all properties of the returned array to be numbers, actual: ${JSON.stringify(prop)}`);
+                assert(prop >= 0, `${inputs} Expected all indices of the returned array to be non-negative, actual: ${JSON.stringify(prop)}`);
+            }
+        };
+
+        try {
+            runTest('', '', undefined, []);
+            runTest('', '', 0, []);
+            runTest('', '', 99, []);
+            runTest('', ':', undefined, ['']);
+            runTest('', ':', 0, []);
+            runTest('', ':', 99, ['']);
+            runTest('abc', '', undefined, ['a', 'b', 'c']);
+            runTest('abc', '', 0, []);
+            runTest('abc', '', 1, ['abc']);
+            runTest('abc', '', 2, ['a', 'bc']);
+            runTest('abc', '', 3, ['a', 'b', 'c']);
+            runTest('abc', '', 99, ['a', 'b', 'c']);
+            runTest('abc', ':', undefined, ['abc']);
+            runTest('abc', ':', 0, []);
+            runTest('abc', ':', 1, ['abc']);
+            runTest('abc', ':', 99, ['abc']);
+            runTest('a:b:c', ':', undefined, ['a', 'b', 'c']);
+            runTest('a:b:c', ':', 0, []);
+            runTest('a:b:c', ':', 1, ['a:b:c']);
+            runTest('a:b:c', ':', 2, ['a', 'b:c']);
+            runTest('a:b:c', ':', 3, ['a', 'b', 'c']);
+            runTest('a:b:c', ':', 99, ['a', 'b', 'c']);
+            runTest('a:b:', ':', undefined, ['a', 'b', '']);
+            runTest('a:b:', ':', 0, []);
+            runTest('a:b:', ':', 1, ['a:b:']);
+            runTest('a:b:', ':', 2, ['a', 'b:']);
+            runTest('a:b:', ':', 3, ['a', 'b', '']);
+            runTest('a:b:', ':', 99, ['a', 'b', '']);
+            runTest('a::c', ':', undefined, ['a', '', 'c']);
+            runTest('a::c', ':', 0, []);
+            runTest('a::c', ':', 1, ['a::c']);
+            runTest('a::c', ':', 2, ['a', ':c']);
+            runTest('a::c', ':', 3, ['a', '', 'c']);
+            runTest('a::c', ':', 99, ['a', '', 'c']);
+            runTest(':b:c', ':', undefined, ['', 'b', 'c']);
+            runTest(':b:c', ':', 0, []);
+            runTest(':b:c', ':', 1, [':b:c']);
+            runTest(':b:c', ':', 2, ['', 'b:c']);
+            runTest(':b:c', ':', 3, ['', 'b', 'c']);
+            runTest(':b:c', ':', 99, ['', 'b', 'c']);
+            runTest('a:/:/b:/:/c', ':/:/', undefined, ['a', 'b', 'c']);
+            runTest('a:/:/b:/:/c', ':/:/', 0, []);
+            runTest('a:/:/b:/:/c', ':/:/', 1, ['a:/:/b:/:/c']);
+            runTest('a:/:/b:/:/c', ':/:/', 2, ['a', 'b:/:/c']);
+            runTest('a:/:/b:/:/c', ':/:/', 3, ['a', 'b', 'c']);
+            runTest('a:/:/b:/:/c', ':/:/', 99, ['a', 'b', 'c']);
+            runTest('a:/:/:/:/c', ':/:/', undefined, ['a', '', 'c']);
+            runTest('a:/:/:/:/c', ':/:/', 0, []);
+            runTest('a:/:/:/:/c', ':/:/', 1, ['a:/:/:/:/c']);
+            runTest('a:/:/:/:/c', ':/:/', 2, ['a', ':/:/c']);
+            runTest('a:/:/:/:/c', ':/:/', 3, ['a', '', 'c']);
+            runTest('a:/:/:/:/c', ':/:/', 99, ['a', '', 'c']);
+            done();
+        } catch (err) {
+            done(new Error(`Test failed: ${err}`));
+        }
+    });
 });

--- a/packages/Ludown/test/ludown.regexEntity.test.suite.js
+++ b/packages/Ludown/test/ludown.regexEntity.test.suite.js
@@ -30,6 +30,30 @@ describe('Regex entities in .lu files', function() {
             .catch(err => done(`Test failed - ${err}`))
     });
 
+    it('are parsed correctly when a valid regex pattern containing slash followed by colon is provided', function(done){
+        let luFileContent = `$slash-colon:/[/:]/`;
+        let regexEntity = new hClasses.regExEntity('slash-colon', '[/:]');
+        parseFile(luFileContent, false)
+            .then(res => {
+                const actualRegexEntity = res.LUISJsonStructure.regex_entities[0];
+                assert.deepEqual(actualRegexEntity, regexEntity, `Expected: ${JSON.stringify(regexEntity)} Actual: ${JSON.stringify(actualRegexEntity)}`);
+                done();
+            })
+            .catch(err => done(`Test failed - ${err} - ${JSON.stringify(err)}`))
+    });
+
+    it('are parsed correctly when a valid regex pattern containing only slash followed by colon is provided', function(done){
+        let luFileContent = `$slash-colon://:/`;
+        let regexEntity = new hClasses.regExEntity('slash-colon', '/:');
+        parseFile(luFileContent, false)
+            .then(res => {
+                const actualRegexEntity = res.LUISJsonStructure.regex_entities[0];
+                assert.deepEqual(actualRegexEntity, regexEntity, `Expected: ${JSON.stringify(regexEntity)} Actual: ${JSON.stringify(actualRegexEntity)}`);
+                done();
+            })
+            .catch(err => done(`Test failed - ${err} - ${JSON.stringify(err)}`))
+    });
+
     it('throws correctly when an empty regex pattern is specified', function(done){
         let luFileContent = `$test://`;
         parseFile(luFileContent, false) 


### PR DESCRIPTION
Fixes #1177

## Proposed Changes
Here is the log of trying to reproduce issue #1177 (in the WSL) after the changes from this PR:
```
$ cat /tmp/Slash.json
{
  "luis_schema_version": "3.2.0",
  "versionId": "0.1",
  "name": "Slash",
  "desc": "",
  "culture": "en-us",
  "tokenizerVersion": "1.0.0",
  "intents": [
    {
      "name": "None"
    }
  ],
  "entities": [],
  "composites": [],
  "closedLists": [],
  "patternAnyEntities": [],
  "regex_entities": [
    {
      "name": "SlashEntity",
      "regexPattern": "/:",
      "roles": []
    }
  ],
  "prebuiltEntities": [],
  "model_features": [],
  "regex_features": [],
  "patterns": [],
  "utterances": [],
  "settings": []
}
$ ./packages/Ludown/bin/ludown d -i /tmp/Slash.json  -o /tmp/ -n Slash.lu
$ cat /tmp/Slash.lu
> ! Automatically generated by [LUDown CLI](https://github.com/Microsoft/botbuilder-tools/tree/master/Ludown), Thu Jun 13 2019 10:37:00 GMT-0400 (DST)

> ! Source LUIS JSON file: /tmp/Slash.json

> ! Source QnA TSV file: Not Specified

> ! Source QnA Alterations file: Not Specified


> # Intent definitions

## None


> # Entity definitions


> # PREBUILT Entity definitions


> # Phrase list definitions


> # List entities

> # RegEx entities

$SlashEntity://:/

$ ./packages/Ludown/bin/ludown parse toluis --in /tmp/Slash.lu -o /tmp/ --out Slash_converted.json
$ cat /tmp/Slash_converted.json
{
  "intents": [
    {
      "name": "None"
    }
  ],
  "entities": [],
  "composites": [],
  "closedLists": [],
  "regex_entities": [
    {
      "name": "SlashEntity",
      "regexPattern": "/:",
      "roles": []
    }
  ],
  "model_features": [],
  "regex_features": [],
  "utterances": [],
  "patterns": [],
  "patternAnyEntities": [],
  "prebuiltEntities": [],
  "luis_schema_version": "3.0.0",
  "versionId": "0.1",
  "name": "Slash",
  "desc": "",
  "culture": "en-us"
```

## Testing
Please refer to the diff to see the tests that were added.