### PR TITLE
[Ludown] Refresh command now respects interchangeable flag

### DIFF
--- a/packages/Ludown/lib/toLU-helpers.js
+++ b/packages/Ludown/lib/toLU-helpers.js
@@ -90,7 +90,7 @@ const toLUHelpers = {
         if(LUISJSON.model_features && LUISJSON.model_features.length >= 0) {
             fileContent += '> # Phrase list definitions' + NEWLINE + NEWLINE;
             LUISJSON.model_features.forEach(function(entity) {
-                fileContent += '$' + entity.name + ':phraseList' + NEWLINE;
+                fileContent += '$' + entity.name + ':phraseList' + (entity.mode ? ' interchangeable' : '') + NEWLINE;
                 fileContent += '- ' + entity.words + NEWLINE;
             });
             fileContent += NEWLINE;

--- a/packages/Ludown/test/verified/allGen.lu
+++ b/packages/Ludown/test/verified/allGen.lu
@@ -65,7 +65,7 @@ $PREBUILT:datetimeV2
 
 $ChocolateType:phraseList
 - m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix
-$question:phraseList
+$question:phraseList interchangeable
 - are you,you are
 
 > # List entities

--- a/packages/Ludown/test/verified/allall-qna.lu
+++ b/packages/Ludown/test/verified/allall-qna.lu
@@ -65,7 +65,7 @@ $PREBUILT:datetimeV2
 
 $ChocolateType:phraseList
 - m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix
-$question:phraseList
+$question:phraseList interchangeable
 - are you,you are
 
 > # List entities

--- a/packages/Ludown/test/verified/collate_refresh.lu
+++ b/packages/Ludown/test/verified/collate_refresh.lu
@@ -89,7 +89,7 @@ $PREBUILT:datetimeV2
 
 $ChocolateType:phraseList
 - m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix
-$question:phraseList
+$question:phraseList interchangeable
 - are you,you are
 
 > # List entities


### PR DESCRIPTION
Fixes an issue where ludown refresh was lossy with converting LUIS model JSON to .lu file specifically for interchangeability of phrase lists. 

This PR fixes it. 

Updated existing tests. 