### PR TITLE
Disable failing tests in LUISGenTestJS. 

### DIFF
--- a/packages/LUISGen/package.json
+++ b/packages/LUISGen/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/Microsoft/botbuilder-tools#readme",
   "scripts": {
     "build": "dotnet build src/LUISGen.csproj",
-    "test": "cd tests/LUISGenTestJS/ && npm run build && npm run test",
+    "testXXX": "cd tests/LUISGenTestJS/ && npm run build && npm run test",
     "clean": "dotnet clean src/LUISGen.csproj && dotnet clean tests/LUISGenTest/LUISGenTest.csproj && cd tests/LUISGenTestJS/ && npm run clean"
   },
   "devDependencies": {


### PR DESCRIPTION
With his last commit, Chrimc told me these tests should not be run. Currently they are breaking the build. (See Botbuilder-tools-js-CI-PR #67944. https://fuselabs.visualstudio.com/SDK_v4/_build/results?buildId=67944&view=results ) (This corrects my mistake of disabling tests in the build when they should have been disabled in the code.)

If chrimc is available, he can review and approve/modify this PR. If not, I suggest we unblock the build by merging this, then let him weigh in when he returns.
