### PR TITLE
[Azure Reverse Proxy][v1.0] Tool to expose localhost using Azure Relay and Hybrid Connection

### DIFF
--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.sln
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29020.237
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureReverseProxy", "AzureReverseProxy\AzureReverseProxy.csproj", "{D1C4F881-15B9-48FF-A57E-EED9564A3D8B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureReverseProxyCMD", "AzureReverseProxyCMD\AzureReverseProxyCMD.csproj", "{1FA33C29-CE71-4448-A790-94CEB768EA08}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D1C4F881-15B9-48FF-A57E-EED9564A3D8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1C4F881-15B9-48FF-A57E-EED9564A3D8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1C4F881-15B9-48FF-A57E-EED9564A3D8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1C4F881-15B9-48FF-A57E-EED9564A3D8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FA33C29-CE71-4448-A790-94CEB768EA08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FA33C29-CE71-4448-A790-94CEB768EA08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FA33C29-CE71-4448-A790-94CEB768EA08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FA33C29-CE71-4448-A790-94CEB768EA08}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F436B7A8-80C5-4F97-8C75-395601F23CA2}
+	EndGlobalSection
+EndGlobal

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AuthorizationRule.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AuthorizationRule.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureReverseProxy
+{
+    public struct AuthorizationRule
+    {
+        public string PrimaryConnectionString { get; set; }
+        public string SecondaryConnectionString { get; set; }
+        public string PrimaryKey { get; set; }
+        public string SecondaryKey { get; set; }
+        public string KeyName { get; set; }
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.csproj
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.csproj
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.csproj
@@ -4,4 +4,21 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Remove="parameters.json" />
+    <None Remove="template.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="parameters.json" />
+    <EmbeddedResource Include="template.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Management.Relay" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.23.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+
 </Project>

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.csproj
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Azure.Management.Relay" Version="2.0.2" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.0.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.23.0" />
+    <PackageReference Include="Microsoft.Azure.Relay" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseTool.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseTool.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace AzureReverseProxy
+{
+    public class AzureReverseTool
+    {
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseTool.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/AzureReverseTool.cs
@@ -1,8 +1,131 @@
-using System;
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Azure.Management.Relay;
+using Microsoft.Azure.Management.ResourceManager;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Microsoft.Azure.Management.ResourceManager.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using System.Reflection;
+using ResourceManagementClient = Microsoft.Azure.Management.ResourceManager.ResourceManagementClient;
 
 namespace AzureReverseProxy
 {
     public class AzureReverseTool
     {
+        private readonly IConfiguration config;
+        private readonly AzureCredentials credentials;
+
+        public AzureReverseTool(IConfiguration config)
+        {
+            this.config = config;
+
+            // Try to obtain the service credentials
+            credentials = new AzureCredentialsFactory().FromServicePrincipal(
+                            config.ClientId,
+                            config.ClientSecret,
+                            config.TenantId,
+                            AzureEnvironment.AzureGlobalCloud);
+        }
+
+        public void GenerateRelayResource()
+        {
+            // Read the template and parameter file contents
+            JObject templateFileContents = GetJsonFileContents("AzureReverseProxy.template.json");
+            JObject parameterFileContents = GetJsonFileContents("AzureReverseProxy.parameters.json");
+
+            // Assign the deplyment name specified by the user
+            parameterFileContents["parameters"]["namespaces_Relay_Demo_name"]["value"] = config.DeploymentName;
+
+            // Create the resource manager client
+            ResourceManagementClient resourceManagementClient = new ResourceManagementClient(credentials)
+            {
+                SubscriptionId = config.SubscriptionId
+            };
+
+            // Create or check that resource group exists
+            EnsureResourceGroupExists(resourceManagementClient, config.ResourceGroupName, config.ResourceGroupLocation);
+
+            // Start a deployment
+            DeployTemplate(resourceManagementClient, config.ResourceGroupName, config.DeploymentName, templateFileContents, parameterFileContents);
+        }
+
+        /// <summary>
+        /// Reads a JSON file from the specified path
+        /// </summary>
+        /// <param name="pathToJson">The full path to the JSON file</param>
+        /// <returns>The JSON file contents</returns>
+        private static JObject GetJsonFileContents(string fileName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            using (Stream stream = assembly.GetManifestResourceStream(fileName))
+            using (StreamReader file = new StreamReader(stream))
+            {
+                using (JsonTextReader reader = new JsonTextReader(file))
+                {
+                    return (JObject)JToken.ReadFrom(reader);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ensures that a resource group with the specified name exists. If it does not, will attempt to create one.
+        /// </summary>
+        /// <param name="resourceManagementClient">The resource manager client.</param>
+        /// <param name="resourceGroupName">The name of the resource group.</param>
+        /// <param name="resourceGroupLocation">The resource group location. Required when creating a new resource group.</param>
+        private async static void EnsureResourceGroupExists(ResourceManagementClient resourceManagementClient, string resourceGroupName, string resourceGroupLocation)
+        {
+            if (await resourceManagementClient.ResourceGroups.CheckExistenceAsync(resourceGroupName) != true)
+            {
+                // Console.WriteLine(string.Format("Creating resource group '{0}' in location '{1}'", resourceGroupName, resourceGroupLocation));
+                var resourceGroup = new ResourceGroup
+                {
+                    Location = resourceGroupLocation
+                };
+
+                await resourceManagementClient.ResourceGroups.CreateOrUpdateAsync(resourceGroupName, resourceGroup);
+            }
+            else
+            {
+                // Console.WriteLine(string.Format("Using existing resource group '{0}'", resourceGroupName));
+            }
+        }
+
+        /// <summary>
+        /// Starts a template deployment.
+        /// </summary>
+        /// <param name="resourceManagementClient">The resource manager client.</param>
+        /// <param name="resourceGroupName">The name of the resource group.</param>
+        /// <param name="deploymentName">The name of the deployment.</param>
+        /// <param name="templateFileContents">The template file contents.</param>
+        /// <param name="parameterFileContents">The parameter file contents.</param>
+        private static void DeployTemplate(ResourceManagementClient resourceManagementClient, string resourceGroupName, string deploymentName, JObject templateFileContents, JObject parameterFileContents)
+        {
+            var deployment = new Deployment
+            {
+                Properties = new DeploymentProperties
+                {
+                    Mode = DeploymentMode.Incremental,
+                    Template = templateFileContents,
+                    Parameters = parameterFileContents["parameters"].ToObject<JObject>()
+                }
+            };
+
+            var deploymentResult = resourceManagementClient.Deployments.CreateOrUpdate(resourceGroupName, deploymentName, deployment);
+            // Console.WriteLine(string.Format("Deployment status: {0}", deploymentResult.Properties.ProvisioningState));
+        }
+
+        public AuthorizationRule GetAuthorizationRule(string ruleName)
+        {
+            RelayManagementClient relayMC = new RelayManagementClient(credentials) { SubscriptionId = config.SubscriptionId };
+
+            var response = relayMC.Namespaces.ListKeysWithHttpMessagesAsync(config.ResourceGroupName, config.DeploymentName, ruleName).Result.Response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            return JsonConvert.DeserializeObject<AuthorizationRule>(response);
+        }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/Configuration.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/Configuration.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AzureReverseProxy
+{
+    public struct Configuration : IConfiguration
+    {
+        public string SubscriptionId { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string ResourceGroupName { get; set; }
+        public string DeploymentName { get; set; }
+
+        /// <summary>
+        /// Must be specified for creating a new resource group
+        /// </summary>
+        public string ResourceGroupLocation { get; set; }
+        public string TenantId { get; set; }
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/Configuration.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/Configuration.cs
@@ -20,5 +20,6 @@ namespace AzureReverseProxy
         /// </summary>
         public string ResourceGroupLocation { get; set; }
         public string TenantId { get; set; }
+        public int Port { get; set; }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/DispatchService.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/DispatchService.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Relay;
+using Newtonsoft.Json;
+
+namespace AzureReverseProxy
+{
+    class DispatcherService
+    {
+        private readonly string _connectionName;
+        readonly HttpClient _httpClient;
+        readonly string _hybridConnectionSubpath;
+        private readonly string _key;
+        private readonly string _keyName;
+        readonly HybridConnectionListener _listener;
+        private readonly string _relayNamespace;
+        private readonly Uri _targetServiceAddress;
+
+        public DispatcherService(string relayNamespace, string connectionName, string keyName, string key, Uri targetServiceAddress)
+        {
+            _relayNamespace = relayNamespace;
+            _connectionName = connectionName;
+            _keyName = keyName;
+            _key = key;
+            _targetServiceAddress = targetServiceAddress;
+
+            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(_keyName, _key);
+            _listener = new HybridConnectionListener(new Uri(string.Format("sb://{0}/{1}", _relayNamespace, _connectionName)), tokenProvider);
+
+            _httpClient = new HttpClient
+            {
+                BaseAddress = targetServiceAddress
+            };
+            _httpClient.DefaultRequestHeaders.ExpectContinue = false;
+
+            _hybridConnectionSubpath = _listener.Address.AbsolutePath.EnsureEndsWith("/");
+        }
+
+        public async Task OpenAsync(CancellationToken cancelToken)
+        {
+            _listener.RequestHandler = ListenerRequestHandler;
+            await _listener.OpenAsync(cancelToken);
+            Console.WriteLine("Azure Service Bus is listening on \n\r\t{0}\n\rand routing requests to \n\r\t{1}\n\r\n\r", _listener.Address, _httpClient.BaseAddress);
+        }
+
+        public Task CloseAsync(CancellationToken cancelToken)
+        {
+            _httpClient.Dispose();
+            return _listener.CloseAsync(cancelToken);
+        }
+
+        private async void ListenerRequestHandler(RelayedHttpListenerContext context)
+        {
+            var startTimeUtc = DateTime.UtcNow;
+            try
+            {
+                Console.WriteLine("Calling {0}...", _targetServiceAddress);
+                var requestMessage = CreateHttpRequestMessage(context);
+                var responseMessage = await _httpClient.SendAsync(requestMessage);
+                await SendResponseAsync(context, responseMessage);
+                await context.Response.CloseAsync();
+            }
+
+            catch (Exception ex)
+            {
+                LogException(ex);
+                SendErrorResponse(ex, context);
+            }
+            finally
+            {
+                LogRequest(startTimeUtc);
+            }
+        }
+
+        private async Task SendResponseAsync(RelayedHttpListenerContext context, HttpResponseMessage responseMessage)
+        {
+            context.Response.StatusCode = responseMessage.StatusCode;
+            context.Response.StatusDescription = responseMessage.ReasonPhrase;
+            foreach (var header in responseMessage.Headers)
+            {
+                if (string.Equals(header.Key, "Transfer-Encoding"))
+                {
+                    continue;
+                }
+
+                context.Response.Headers.Add(header.Key, string.Join(",", header.Value));
+            }
+
+            var responseStream = await responseMessage.Content.ReadAsStreamAsync();
+            await responseStream.CopyToAsync(context.Response.OutputStream);
+        }
+
+        private void SendErrorResponse(Exception ex, RelayedHttpListenerContext context)
+        {
+            context.Response.StatusCode = HttpStatusCode.InternalServerError;
+            context.Response.StatusDescription = $"Internal Server Error: {ex.GetType().FullName}: {ex.Message}";
+            context.Response.Close();
+        }
+
+        private HttpRequestMessage CreateHttpRequestMessage(RelayedHttpListenerContext context)
+        {
+            var requestMessage = new HttpRequestMessage();
+            if (context.Request.HasEntityBody)
+            {
+                requestMessage.Content = new StreamContent(context.Request.InputStream);
+                
+                var contentType = context.Request.Headers[HttpRequestHeader.ContentType];
+                if (!string.IsNullOrEmpty(contentType))
+                {
+                    requestMessage.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
+                }
+            }
+
+            var relativePath = context.Request.Url.GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
+            relativePath = relativePath.Replace(_hybridConnectionSubpath, string.Empty, StringComparison.OrdinalIgnoreCase);
+            requestMessage.RequestUri = new Uri(relativePath, UriKind.RelativeOrAbsolute);
+            requestMessage.Method = new HttpMethod(context.Request.HttpMethod);
+
+            foreach (var headerName in context.Request.Headers.AllKeys)
+            {
+                if (string.Equals(headerName, "Host", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(headerName, "Content-Type", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Don't flow these headers here
+                    continue;
+                }
+
+                requestMessage.Headers.Add(headerName, context.Request.Headers[headerName]);
+            }
+
+            return requestMessage;
+        }
+
+        private void LogRequest(DateTime startTimeUtc)
+        {
+            var stopTimeUtc = DateTime.UtcNow;
+
+            Console.WriteLine("...and back {0:N0} ms...", stopTimeUtc.Subtract(startTimeUtc).TotalMilliseconds);
+            Console.WriteLine("");
+        }
+
+        private void LogRequestActivity(HttpRequestMessage requestMessage)
+        {
+            var content = requestMessage.Content.ReadAsStringAsync().Result;
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            var s = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented
+            };
+
+            dynamic o = JsonConvert.DeserializeObject(content);
+            var formatted = JsonConvert.SerializeObject(o, s);
+            Console.WriteLine(formatted);
+            Console.ResetColor();
+        }
+
+        private static void LogException(Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(ex);
+            Console.WriteLine("");
+            Console.ResetColor();
+        }
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/IConfiguration.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/IConfiguration.cs
@@ -12,5 +12,6 @@ namespace AzureReverseProxy
         string ResourceGroupName { get; set; }
         string SubscriptionId { get; set; }
         string TenantId { get; set; }
+        int Port { get; set; }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/IConfiguration.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/IConfiguration.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace AzureReverseProxy
+{
+    public interface IConfiguration
+    {
+        string ClientId { get; set; }
+        string ClientSecret { get; set; }
+        string DeploymentName { get; set; }
+        string ResourceGroupLocation { get; set; }
+        string ResourceGroupName { get; set; }
+        string SubscriptionId { get; set; }
+        string TenantId { get; set; }
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/StringEx.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/StringEx.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace AzureReverseProxy
+{
+    public static class StringEx
+    {
+        /// <summary>
+        /// Ensures the given string ends with the requested pattern. If it does no allocations are performed.
+        /// </summary>
+        public static string EnsureEndsWith(this string s, string value, StringComparison comparisonType = StringComparison.Ordinal)
+        {
+            if (!string.IsNullOrEmpty(s) && s.EndsWith(value, comparisonType))
+            {
+                return s;
+            }
+
+            return s + value;
+        }
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/parameters.json
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/parameters.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaces_Relay_Demo_name": {
+      "value": null
+    }
+  }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/template.json
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxy/template.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaces_Relay_Demo_name": {
+      "defaultValue": "Relay-Demo",
+      "type": "String"
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Relay/namespaces",
+      "apiVersion": "2017-04-01",
+      "name": "[parameters('namespaces_Relay_Demo_name')]",
+      "location": "West US",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      },
+      "properties": {
+        "provisioningState": "Succeeded",
+        "metricId": "replace-with-subscription-id:relay-demo",
+        "createdAt": "2019-07-04T16:40:59.857Z",
+        "updatedAt": "2019-07-04T16:41:44.717Z",
+        "serviceBusEndpoint": "[concat('https://', parameters('namespaces_Relay_Demo_name'), '.servicebus.windows.net:443/')]"
+      }
+    },
+    {
+      "type": "Microsoft.Relay/namespaces/AuthorizationRules",
+      "apiVersion": "2017-04-01",
+      "name": "[concat(parameters('namespaces_Relay_Demo_name'), '/RootManageSharedAccessKey')]",
+      "location": "West US",
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('namespaces_Relay_Demo_name'))]"
+      ],
+      "properties": {
+        "rights": [
+          "Listen",
+          "Manage",
+          "Send"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Relay/namespaces/AuthorizationRules",
+      "apiVersion": "2017-04-01",
+      "name": "[concat(parameters('namespaces_Relay_Demo_name'), '/sas-rule')]",
+      "location": "West US",
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('namespaces_Relay_Demo_name'))]"
+      ],
+      "properties": {
+        "rights": [
+          "Listen",
+          "Send"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Relay/namespaces/hybridConnections",
+      "apiVersion": "2017-04-01",
+      "name": "[concat(parameters('namespaces_Relay_Demo_name'), '/demo-hybrid-connection')]",
+      "location": "West US",
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('namespaces_Relay_Demo_name'))]"
+      ],
+      "properties": {
+        "createdAt": "2019-07-04T16:43:21.3465954Z",
+        "updatedAt": "2019-07-04T16:43:21.3465954Z",
+        "requiresClientAuthorization": false
+      }
+    }
+  ]
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/AzureReverseProxyCMD.csproj
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/AzureReverseProxyCMD.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/AzureReverseProxyCMD.csproj
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/AzureReverseProxyCMD.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <StartupObject>AzureReverseProxyCMD.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/AzureReverseProxyCMD.csproj
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/AzureReverseProxyCMD.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\AzureReverseProxy\AzureReverseProxy.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
@@ -1,5 +1,9 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using AzureReverseProxy;
 using Newtonsoft.Json;
 
@@ -8,15 +12,46 @@ namespace AzureReverseProxyCMD
     class Program
     {
         private static AzureReverseTool AZProxy;
+        private static bool DeleteResource = false;
+        private static bool Run = true;
         static void Main(string[] args)
         {
             AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
 
-            var config = GetConfiguration();
+            // Event to stop the process
+            Console.CancelKeyPress += delegate (object sender, ConsoleCancelEventArgs e) {
+                e.Cancel = true;
+                Run = false;
+                AZProxy.CloseListener().GetAwaiter().GetResult();
+            };
 
-            Console.WriteLine($"Deploying { config.DeploymentName } to group { config.ResourceGroupName }...");
+            MainAsync().Wait();
+        }
+
+        private static async Task MainAsync()
+        {
+            var config = GetConfiguration();
             AZProxy = new AzureReverseTool(config);
-            AZProxy.GenerateRelayResource();
+
+            Console.WriteLine($"Check existence of '{ config.DeploymentName }' in '{ config.ResourceGroupName }' group...");
+            if (!AZProxy.CheckExistence())
+            {
+                Console.WriteLine($"'{ config.DeploymentName }' was not found. Deploying to '{ config.ResourceGroupName }' group...");
+                AZProxy.GenerateRelayResource();
+                Console.WriteLine($"'{ config.DeploymentName }' created.");
+            }
+            else
+            {
+                Console.WriteLine($"'{ config.DeploymentName }' found.");
+            }
+
+            Console.WriteLine("Starting listener...\n");
+            await AZProxy.StartListener();
+
+            while (Run)
+            {
+                await Task.Delay(100);
+            }
         }
 
         private static IConfiguration GetConfiguration()
@@ -32,8 +67,17 @@ namespace AzureReverseProxyCMD
 
         private static void OnProcessExit(object sender, EventArgs e)
         {
-            Console.WriteLine(Environment.NewLine + "Deleting the generated resources...");
-            AZProxy.DeleteResource();
+            if (AZProxy != null)
+            {
+                AZProxy.CloseListener().GetAwaiter().GetResult();
+            }
+
+            if (DeleteResource)
+            {
+                Console.WriteLine(Environment.NewLine + "Deleting the generated resources...");
+                AZProxy.DeleteResource();
+                Console.WriteLine("\nThe resurce was eliminated.");
+            }
         }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+using System;
+using System.IO;
+using AzureReverseProxy;
+using Newtonsoft.Json;
 
 namespace AzureReverseProxyCMD
 {
@@ -6,7 +9,19 @@ namespace AzureReverseProxyCMD
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            var az = new AzureReverseTool(GetConfiguration());
+            az.GenerateRelayResource();
+        }
+
+        private static IConfiguration GetConfiguration()
+        {
+            var folder = AppDomain.CurrentDomain.BaseDirectory;
+            var file = "appsettings.json";
+
+            using (StreamReader reader = new StreamReader(Path.Combine(folder, file)))
+            {
+                return JsonConvert.DeserializeObject<Configuration>(reader.ReadToEnd());
+            }
         }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace AzureReverseProxyCMD
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/Program.cs
@@ -7,10 +7,16 @@ namespace AzureReverseProxyCMD
 {
     class Program
     {
+        private static AzureReverseTool AZProxy;
         static void Main(string[] args)
         {
-            var az = new AzureReverseTool(GetConfiguration());
-            az.GenerateRelayResource();
+            AppDomain.CurrentDomain.ProcessExit += new EventHandler(OnProcessExit);
+
+            var config = GetConfiguration();
+
+            Console.WriteLine($"Deploying { config.DeploymentName } to group { config.ResourceGroupName }...");
+            AZProxy = new AzureReverseTool(config);
+            AZProxy.GenerateRelayResource();
         }
 
         private static IConfiguration GetConfiguration()
@@ -22,6 +28,12 @@ namespace AzureReverseProxyCMD
             {
                 return JsonConvert.DeserializeObject<Configuration>(reader.ReadToEnd());
             }
+        }
+
+        private static void OnProcessExit(object sender, EventArgs e)
+        {
+            Console.WriteLine(Environment.NewLine + "Deleting the generated resources...");
+            AZProxy.DeleteResource();
         }
     }
 }

--- a/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/appsettings.json
+++ b/AzureReverseProxy/AzureReverseProxy/AzureReverseProxyCMD/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "subscriptionId": "",
+  "clientId": "",
+  "clientSecret": "",
+  "resourceGroupName": "",
+  "deploymentName": "",
+  "resourceGroupLocation": null,
+  "tenantId": "",
+  "Port": 3978
+}


### PR DESCRIPTION
## Description
Azure Reverse Proxy is an open source tool that securely exposes a local host using Azure Relay with Hybrid Connections.

The solution is divided into two projects, the Azure Reverse Proxy and the command line application that implements it.

The command line tool deploys an Azure Relay resource using a template, therefore it needs a configuration with the following information:
- **Subscription Id.** Required for the resource deployment.
- **Client Id.** Required for the resource deployment.
- **Client Secret.** Required for the resource deployment.
- **Resource Group Name.** Required for the resource deployment.
- **Deployment Name.** Required for the resource deployment.
- **Resource Group Location.** Required for the resource deployment only if the Resource Group doesnt exist.
- **Tenant Id.** Required for the resource deployment.
- **Port.** Port number to open.

If the resource already exists, it connects directly to it.

## How to run the tool
First it is necessary to copy the file `appsettings.json` to the folder where `AzureReverseProxyCMD.dll` is and complete it fields with the information specified above.

Then it is just necessary to run the following command:
```
Dotnet AzureReverseProxyCMD.dll
```
The tool then will load the configuration from a file `appsettings.json`, checks if the resource exists and if it does it open a connection between the localhost port specified in the configuration and the Hybrid Connection URL.

If the resource doesn't exist, it will create it using a pre-made template.

![ARP demo](https://user-images.githubusercontent.com/39467613/61138798-75397a80-a49e-11e9-9aa2-b3e9ba205d62.gif)

## Known issues
Unless the flag `DeleteResource` is set to false, the tool will delete the created resource when closing or exiting the tool by using the event `AppDomain.CurrentDomain.ProcessExit`.

However, there is a time frame of 5 seconds before Windows terminates all the threads associated with the process. This means if for some reason it takes more than 5 seconds to execute the delete command (for example, when debugging) it will not delete the resource.

## Next steps
We know that the need of an Azure account is a limitation for many users, therefore for the next version we plan for the tool to connect to a default Relay and Hybrid Connection resource if no configuration is provided. The user will only have to provide the port number to use.

We also plan to make the interface more similar to Ngrok's.