### PR TITLE
[ludown] Fix for index 0 being assigned -1

### DIFF
--- a/packages/Ludown/lib/classes/hclasses.js
+++ b/packages/Ludown/lib/classes/hclasses.js
@@ -13,8 +13,8 @@ const readerObj = {
         constructor(entity, value, start, end) {
             this.entity = entity?entity:'';
             this.value = value?value:'';
-            this.start = start?start:-1;
-            this.end = end?end:-1;
+            this.start = !isNaN(start)?start:-1;
+            this.end = !isNaN(end)?end:-1;
         }
     },
     intent: class {

--- a/packages/Ludown/test/ludown.translate.test.suite.js
+++ b/packages/Ludown/test/ludown.translate.test.suite.js
@@ -215,4 +215,21 @@ describe('With translate module', function() {
             })
             .catch (err => done(err));
     }); 
+
+    it('Utterance starting with entity is parsed correctly', function(done) {
+        if (!TRANSLATE_KEY) {
+            this.skip();
+        }
+        let fileContent = txtfile.readSync(resolvePath('test/testcases/translate-with-number.lu'));
+        trHelpers.parseAndTranslate(fileContent, TRANSLATE_KEY, 'de', '', true, false, SHOW_LOGS)
+            .then(function(res) {
+                try {
+                    compareFiles(res, LUDOWN_ROOT + '/test/verified/de/translate-with-number.lu');
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            })
+            .catch (err => done(err));
+    });
 });

--- a/packages/Ludown/test/testcases/translate-with-number.lu
+++ b/packages/Ludown/test/testcases/translate-with-number.lu
@@ -1,0 +1,2 @@
+# Test
+- {Number:numberOfAdults=2} adults, {Number:numberOfChildren=1} child

--- a/packages/Ludown/test/verified/de/translate-with-number.lu
+++ b/packages/Ludown/test/verified/de/translate-with-number.lu
@@ -1,0 +1,2 @@
+# Test
+-  {Number:numberOfAdults=2}  Erwachsene  {Number:numberOfChildren=1} kind


### PR DESCRIPTION
Fixes #1213 

## Proposed Changes
In the translate scenario when utterance begins with single character (number) the entity was constructed with start and end index = -1 (start is 0, end is 0, therefore `start?start:-1` translates into -1).

Example:
```
> source - entity length = 1
{Number:numberOfAdults=2} vuxna, {Number:numberOfAdults=1} barn
> translation
{Number:numberOfAdults=} 2 adults,  {Number:numberOfAdults=1}  Children
---------
> source - entity length > 1
{Number:numberOfAdults=Twa} vuxna, {Number:numberOfAdults=1} barn
> translation
{Number:numberOfAdults=Two}  Adults,  {Number:numberOfAdults=1}  Children
```

After fix:
```
> source
{Number:numberOfAdults=2} vuxna, {Number:numberOfAdults=1} barn
>translation
{Number:numberOfAdults=2}  Adults,  {Number:numberOfAdults=1}  Children
```