### PR TITLE
Bump versions in prep for 4.5 release cycle

### DIFF
--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luis-apis",
-  "version": "3.0.0",
+  "version": "2.6.0",
   "description": "Tooling for connectivity with LUIS APIs",
   "main": "./lib/luisAuthoring.js",
   "types": "./typings/lib/luisAuthoring.d.ts",

--- a/packages/LUISGen/src/LUISGen.csproj
+++ b/packages/LUISGen/src/LUISGen.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>2.0.1</VersionPrefix>
+        <VersionPrefix>2.2.0</VersionPrefix>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -36,9 +36,9 @@
         <ToolCommandName>luisgen</ToolCommandName>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <AssemblyVersion>2.1.2.0</AssemblyVersion>
-        <FileVersion>2.1.2.0</FileVersion>
-        <Version>2.1.1-local</Version>
+        <AssemblyVersion>2.2.0.0</AssemblyVersion>
+        <FileVersion>2.2.0.0</FileVersion>
+        <Version>2.2.0-local</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/packages/LUISGen/src/npm/package.json
+++ b/packages/LUISGen/src/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luisgen",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "LUISGen is a tool for generating C# class or Typescript interface for a LUIS app to make consuming LUIS output easier.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps versions of tools to martch the 4.5 target release. Our target versions are:

Tool | Target
-- | --
LuisGen | 2.2.0
BotDispatch | 1.5.0
Chatdown | 1.2.3
Ludown | 1.3.2
luis-api | 2.6.0
qnamaker | 1.3.1
Msbot | 4.3.6


