### PR TITLE
Fix for #1151 - Allow phrase lists to have same name as other entity types in labelled utterances

### DIFF
--- a/packages/Ludown/lib/parseFileContents.js
+++ b/packages/Ludown/lib/parseFileContents.js
@@ -777,16 +777,13 @@ const VerifyAndUpdateSimpleEntityCollection = function (parsedContent, entityNam
     });
 
     if (entityExistsInUtteranceLabel !== undefined) {
-        if (entityType === 'Phrase List') {
-            throw (new exception(retCode.errorCode.INVALID_INPUT, `[ERROR]: '${entityType}' entity: "${entityName}" is added as a labelled entity in utterance "${entityExistsInUtteranceLabel.text}". ${entityType} cannot be added with explicit labelled values in utterances.`));
-        }
         let entityMatch = entityExistsInUtteranceLabel.entities.filter(item => item.entity == entityName);
         entityMatch.forEach(entity => {
             if (entity.role !== undefined) {
                 if (!entityRoles.includes(entity.role)) {
                     entityRoles.push(entity.role);
                 }
-            } else {
+            } else if (entityType !== 'Phrase List') {              // Fix for # 1151. Phrase lists can have same name as other entities.
                 throw (new exception(retCode.errorCode.INVALID_INPUT, `[ERROR]: '${entityType}' entity: "${entityName}" is added as a labelled entity in utterance "${entityExistsInUtteranceLabel.text}". ${entityType} cannot be added with explicit labelled values in utterances.`));
             }
         });

--- a/packages/Ludown/test/ludown.parsefile.test.suite.js
+++ b/packages/Ludown/test/ludown.parsefile.test.suite.js
@@ -878,4 +878,24 @@ describe('parseFile correctly parses utterances', function () {
 
         })
 
+        it ('Test for 1151, phrase list can have same name as labelled simple entity', function(done){
+                let testLu = `## RequestItem
+                - i need more {Item=water}
+                
+                $Item:simple
+                
+                $Item:phraseList interchangeable
+                - water,coffee`;
+                parseFile.parseFile(testLu)
+                        .then(res => {
+                                assert.equal(res.LUISJsonStructure.entities.length, 1);
+                                assert.equal(res.LUISJsonStructure.entities[0].name, 'Item');
+                                assert.equal(res.LUISJsonStructure.model_features.length, 1);
+                                assert.equal(res.LUISJsonStructure.model_features[0].name, 'Item');
+                                done();
+                        })
+                        .catch(err => done(err))
+
+        })
+
 })

--- a/packages/Ludown/test/ludown.roleTests.test.suite.js
+++ b/packages/Ludown/test/ludown.roleTests.test.suite.js
@@ -360,7 +360,16 @@ describe('Roles in LU files', function() {
 - m&m,mars,mints,spearmings,payday,jelly,kit kat,kitkat,twix`;
 
         parser.parseFile(testLU, false, null)
-            .then (res => done(`Test failed - ${JSON.stringify(res)}`))
+            .then (res => {
+                // This is fix for # 1151. LUIS allows phrase list names to be the same name as other entities in the model. 
+                assert.equal(res.LUISJsonStructure.entities.length, 1);
+                assert.equal(res.LUISJsonStructure.entities[0].name, 'test');
+                assert.equal(res.LUISJsonStructure.entities[0].roles.length, 1);
+                assert.deepEqual(res.LUISJsonStructure.entities[0].roles, ['fromTime']);
+                assert.equal(res.LUISJsonStructure.model_features.length, 1);
+                assert.equal(res.LUISJsonStructure.model_features[0].name, 'test');
+                done();
+            })
             .catch (err => done ())
     })
 


### PR DESCRIPTION
Fixes #1151 

## Testing
- Updated existing tests.
- Added new tests.