### PR TITLE
[Ludown] Skip QnA meta data filters from translation.

### DIFF
--- a/packages/Ludown/lib/translate-helpers.js
+++ b/packages/Ludown/lib/translate-helpers.js
@@ -83,6 +83,12 @@ const translateHelpers = {
                     this.addSegment(linesToTranslate, NEWLINE, false);
                     continue;
                 }
+                // Fix for #1191. Do not localize meta-data filters for QnA.
+                if (currentSectionType === PARSERCONSTS.FILTER) {
+                    this.addSegment(linesToTranslate, currentLine, false);
+                    this.addSegment(linesToTranslate, NEWLINE, false);
+                    continue;
+                }
                 let listSeparator = '';
                 let content = '';
                 switch (currentSectionType) {

--- a/packages/Ludown/test/ludown.translate.test.suite.js
+++ b/packages/Ludown/test/ludown.translate.test.suite.js
@@ -247,4 +247,31 @@ describe('With translate module', function() {
             })
             .catch(err => done(err))
     });
+
+    it('correctly localizes metadata filters for QnA', function(done) {
+        if(!TRANSLATE_KEY) {
+            this.skip();
+        }
+        let luFile = helpers.sanitizeNewLines(`## ? First question.
+        - Alternate first question.
+        
+        **Filters:**
+        - metatag = first
+        
+        `);
+        let expectedOutput = helpers.sanitizeNewLines(`## ? Première question.
+- Première question alternative.
+
+**Filters:**
+- metatag = first
+
+
+`);
+        trHelpers.parseAndTranslate(luFile, TRANSLATE_KEY, 'fr', null, false, false, false)
+            .then(res => {
+                assert.equal(res, expectedOutput);
+                done();
+            })
+            .catch(err => done(err))
+    });
 });


### PR DESCRIPTION
Fixes #1191 

## Proposed Changes
- QnA meta data filters were included in machine translation which results in incorrect behavior. This information should not be translated. This PR fixes it. 


## Testing
Added new test to verify intended behavior.