### PR TITLE
[Ludown] respect --lu_file option for translate command

### DIFF
--- a/packages/Ludown/docs/commands.md
+++ b/packages/Ludown/docs/commands.md
@@ -141,7 +141,7 @@ To bootstrap translations of the language understanding content for your bot, yo
     -o, --out_folder <outputFolder>  [Optional] Output folder for all files the tool will generate
     -f, --src_lang                   [Optional] Source language. When omitted, source language is automatically detected. See https://aka.ms/translate-langs for list of supported languages and codes
     -s, --subfolder                  [Optional] Include sub-folders as well when looking for .lu files
-    -n, --lu_File <LU_File>          [Optional] Output .lu file name
+    -n, -n, --lu_file <lu file name> [Optional] Output .lu file name
     -c, --transate_comments          [Optional] Translate comments in .lu files
     -u, --translate_link_text        [Optional] Translate URL or .lu file reference link text
     -b, --batch_translate <linesToBatch>  [Optional] Batch up <x> (1-25) number of lines before calling translation API. Defaults to 25.

--- a/packages/Ludown/docs/translate-command.md
+++ b/packages/Ludown/docs/translate-command.md
@@ -34,7 +34,7 @@ When translating .lu file,
     -o, --out_folder <outputFolder>  [Optional] Output folder for all files the tool will generate
     -f, --src_lang                   [Optional] Source language. When omitted, source language is automatically detected. See https://aka.ms/translate-langs for list of supported languages and codes
     -s, --subfolder                  [Optional] Include sub-folders as well when looking for .lu files
-    -n, --lu_File <LU_File>          [Optional] Output .lu file name
+    -n, -n, --lu_file <lu file name> [Optional] Output .lu file name
     -c, --transate_comments          [Optional] Translate comments in .lu files
     -u, --translate_link_text        [Optional] Translate URL or .lu file reference link text
     -b, --batch_translate <linesToBatch>  [Optional] Batch up <x> (1-25) number of lines before calling translation API. Defaults to 25.

--- a/packages/Ludown/lib/ludown-translate.js
+++ b/packages/Ludown/lib/ludown-translate.js
@@ -23,7 +23,7 @@ program
     .option('-o, --out_folder <outputFolder>', '[Optional] Output folder for all files the tool will generate')
     .option('-f, --src_lang <srcLang>', '[Optional] Source language. When omitted, source language is automatically detected. See https://aka.ms/translate-langs for list of supported languages and codes')
     .option('-s, --subfolder', '[Optional] Include sub-folders as well when looking for .lu files')
-    .option('-n, --lu_File <LU_File>', '[Optional] Output .lu file name')
+    .option('-n, --lu_file <lu file name>', '[Optional] Output .lu file name')
     .option('-c, --translate_comments', '[Optional] Translate comments in .lu files')
     .option('-u, --translate_link_text', '[Optional] Translate URL or .lu file reference link text')
     .option('-b, --batch_translate <linesToBatch>', '[Optional] Batch up <x> (1-25) number of lines before calling translation API. Defaults to 25.')

--- a/packages/Ludown/lib/translate.js
+++ b/packages/Ludown/lib/translate.js
@@ -60,7 +60,7 @@ const translateModule = {
         while(filesToParse.length > 0) {
             let file = filesToParse[0];
             try {
-                await parseFile(file, outFolder, program.translate_key, program.to_lang, program.src_lang, program.translate_comments, program.translate_link_text, program.verbose, program.batch_translate);
+                await parseFile(file, outFolder, program.translate_key, program.to_lang, program.src_lang, program.translate_comments, program.translate_link_text, program.verbose, program.batch_translate, program.lu_file);
             } catch (err) {
                 throw(err);
             }
@@ -80,11 +80,12 @@ const translateModule = {
  * @param {boolean} translate_link_text translate URL or LU reference link text in .lu files if this is set to true
  * @param {boolean} log indicates if this function should write verbose messages to process.stdout
  * @param {number} batch_translate indicates number of input lines to batch up before calling translation API
+ * @param {string} lu_file output file name requested
  * @returns {void} nothing
  * @throws {exception} Throws on errors. exception object includes errCode and text. 
  */
-async function parseFile(file, outFolder, translate_key, to_lang, src_lang, translate_comments, translate_link_text, log, batch_translate) {
-    let fileName = path.basename(file);
+async function parseFile(file, outFolder, translate_key, to_lang, src_lang, translate_comments, translate_link_text, log, batch_translate, lu_file) {
+    let fileName = lu_file ? lu_file : path.basename(file);
     if(!fs.existsSync(path.resolve(file))) {
         throw(new exception(retCode.errorCode.FILE_OPEN_ERROR, 'Sorry unable to open [' + file + ']'));
     }


### PR DESCRIPTION
Fixes #1211 

## Proposed Changes
Ludown translate command provided an option for users to set an output lu_file name which was not respected. This PR fixes it. 

## Testing
Verified existing tests pass.