### PR TITLE
Adding / updating community docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). 
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
+ [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 # Instructions for Contributing Code
 
 ## Contributing bug fixes and features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,24 @@
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+# Instructions for Contributing Code
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+## Contributing bug fixes and features
+
+The Bot Framework team is currently accepting contributions in the form of bug fixes and new 
+features. Any submission must have an issue tracking it in the issue tracker that has
+ been approved by the Bot Framework team. Your pull request should include a link to 
+ the bug that you are fixing. If you've submitted a PR for a bug, please post a 
+ comment in the bug to avoid duplication of effort.
+
+## Legal
+
+If your contribution is more than 15 lines of code, you will need to complete a Contributor 
+License Agreement (CLA). Briefly, this agreement testifies that you are granting us permission
+ to use the submitted change according to the terms of the project's license, and that the work
+  being submitted is under appropriate copyright.
+
+Please submit a Contributor License Agreement (CLA) before submitting a pull request. 
+You may visit https://cla.azure.com to sign digitally. Alternatively, download the 
+agreement ([Microsoft Contribution License Agreement.docx](https://www.codeplex.com/Download?ProjectName=typescript&DownloadId=822190) or
+ [Microsoft Contribution License Agreement.pdf](https://www.codeplex.com/Download?ProjectName=typescript&DownloadId=921298)), sign, scan, 
+ and email it back to <cla@microsoft.com>. Be sure to include your github user name along with the agreement. Once we have received the 
+ signed CLA, we'll review the request. 


### PR DESCRIPTION
Fixes #1445

Adds;

- Code of conduct doc (link to MS Community code of conduct)
- Contribution guidelines aligned with other SDK repos