### PR TITLE
Bug: get_Suggestions methods don't exist, use closest matching

### DIFF
--- a/packages/LUIS/bin/luis.js
+++ b/packages/LUIS/bin/luis.js
@@ -550,10 +550,10 @@ async function runProgram() {
         case "suggest":
             switch (target) {
                 case "intents":
-                    result = await client.model.getIntentSuggestions(args.appId, args.versionId, args.intentId, args);
+                    result = await client.model.listIntentSuggestions(args.appId, args.versionId, args.intentId, args);
                     break;
                 case "entities":
-                    result = await client.model.getEntitySuggestions(args.appId, args.versionId, args.entityId, args);
+                    result = await client.model.listEntitySuggestions(args.appId, args.versionId, args.entityId, args);
                     break;
 
                 default:


### PR DESCRIPTION
Fixes #1479 

## Proposed Changes
`getIntentSuggestions` and `getEntitySuggestions` methods do not exist. Calling `suggest` API as documented will fail:
`luis suggest intents --intentId "<IntentId>"`

Using closest matching methods `listIntentSuggestions` and `listEntitySuggestions` instead.

## Testing
Customer and local verified.