### PR TITLE
Update README.md - added Dispatch deprecation text and link to Orchestrator doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The Bot Framework SDK team is happy to announce the General Availability of the consolidated bot framework CLI tool [bf-cli](https://aka.ms/bfcli). The new BF CLI tool will replace legacy standalone tools to manage Bot Framework bots and related services. The old tools will be ported over in phases and all new features, bug fixes, and further investments will focus on the new BF CLI.  Old tools will still work for the time being, but they are going to be deprecated in future releases.
 
-Upon the release of Bot Framework SDK version 4.6 the following legacy tools have been ported: Chatdown, QnAMaker, LuisGen, and LuDown.
+Upon the release of Bot Framework SDK version 4.6 the following legacy tools have been ported: Chatdown, QnAMaker, LuisGen, and LuDown.  Dispatch CLI is on the path to be deprecated and replaced with [Orchestrator](https://aka.ms/bf-orchestrator).
 
 To learn more about the BF CLI please visit the [BF CLI github repository](https://aka.ms/bfcli).
 


### PR DESCRIPTION
Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->
#1516 

## Proposed Changes
Added Dispatch deprecation verbiage on botbuilder-tools main README