### PR TITLE
Fix broken build Botbuilder-tools-js-CI-PR

### DIFF
--- a/packages/LUIS/package-lock.json
+++ b/packages/LUIS/package-lock.json
@@ -384,15 +384,6 @@
         "once": "^1.4.0"
       }
     },
-    "enum-files": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/enum-files/-/enum-files-1.1.0.tgz",
-      "integrity": "sha1-kH8VWSoP8DGyyK85LfNwrsOG5aU=",
-      "dev": true,
-      "requires": {
-        "bluebird": "*"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/packages/LUIS/package-lock.json
+++ b/packages/LUIS/package-lock.json
@@ -384,6 +384,14 @@
         "once": "^1.4.0"
       }
     },
+    "enum-files": {
+      "version": "git+https://github.com/hirowaki/enum-files.git#1c59396d7188bdccb5d3de72e83adfafeb19b9aa",
+      "from": "git+https://github.com/hirowaki/enum-files.git",
+      "dev": true,
+      "requires": {
+        "bluebird": "*"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/packages/LUIS/package.json
+++ b/packages/LUIS/package.json
@@ -60,7 +60,7 @@
     "window-size": "^1.1.0"
   },
   "devDependencies": {
-    "enum-files": "^1.1.0",
+    "enum-files": "git+https://github.com/hirowaki/enum-files.git",
     "mocha": "^5.2.0",
     "rollup": "^0.66.2",
     "rollup-plugin-node-resolve": "^3.4.0",

--- a/packages/MSBot/package-lock.json
+++ b/packages/MSBot/package-lock.json
@@ -313,15 +313,6 @@
         "once": "^1.4.0"
       }
     },
-    "enum-files": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/enum-files/-/enum-files-1.1.0.tgz",
-      "integrity": "sha1-kH8VWSoP8DGyyK85LfNwrsOG5aU=",
-      "dev": true,
-      "requires": {
-        "bluebird": "*"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/packages/MSBot/package-lock.json
+++ b/packages/MSBot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbot",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -311,6 +311,14 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enum-files": {
+      "version": "git+https://github.com/hirowaki/enum-files.git#1c59396d7188bdccb5d3de72e83adfafeb19b9aa",
+      "from": "git+https://github.com/hirowaki/enum-files.git",
+      "dev": true,
+      "requires": {
+        "bluebird": "*"
       }
     },
     "escape-string-regexp": {

--- a/packages/MSBot/package.json
+++ b/packages/MSBot/package.json
@@ -45,7 +45,7 @@
     "@types/semver": "^5.5.0",
     "@types/uuid": "^3.4.3",
     "@types/valid-url": "^1.0.2",
-    "enum-files": "^1.1.0",
+    "enum-files": "git+https://github.com/hirowaki/enum-files.git",
     "mocha": "^5.2.0",
     "targz": "^1.0.1"
   },

--- a/packages/QnAMaker/package-lock.json
+++ b/packages/QnAMaker/package-lock.json
@@ -346,15 +346,6 @@
         "once": "^1.4.0"
       }
     },
-    "enum-files": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/enum-files/-/enum-files-1.1.0.tgz",
-      "integrity": "sha1-kH8VWSoP8DGyyK85LfNwrsOG5aU=",
-      "dev": true,
-      "requires": {
-        "bluebird": "*"
-      }
-    },
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",

--- a/packages/QnAMaker/package-lock.json
+++ b/packages/QnAMaker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qnamaker",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -344,6 +344,14 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enum-files": {
+      "version": "git+https://github.com/hirowaki/enum-files.git#1c59396d7188bdccb5d3de72e83adfafeb19b9aa",
+      "from": "git+https://github.com/hirowaki/enum-files.git",
+      "dev": true,
+      "requires": {
+        "bluebird": "*"
       }
     },
     "es6-promise": {

--- a/packages/QnAMaker/package.json
+++ b/packages/QnAMaker/package.json
@@ -51,7 +51,7 @@
     "window-size": "^1.1.0"
   },
   "devDependencies": {
-    "enum-files": "^1.1.0",
+    "enum-files": "git+https://github.com/hirowaki/enum-files.git",
     "mocha": "^5.2.0",
     "targz": "^1.0.1"
   }


### PR DESCRIPTION
Fixes #minor

## Description

Botbuilder-tools-js-CI-PR is failing.

[Task npm run build](https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=300882&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=2c7de9cf-37f6-5488-01cf-84e0559e436a&l=100) fails with:
npm ERR! 404 Not Found - GET https://registry.npmjs.org/enum-files/-/enum-files-1.1.0.tgz
enum-files is no longer available on npmjs.com, but is available here:
https://github.com/hirowaki/enum-files

## Proposed Changes
This switches to installing enum-files from GitHub instead of npmrc.com.